### PR TITLE
ci: distro-native release artefacts via GitHub Actions

### DIFF
--- a/.github/workflows/release-artefacts.yml
+++ b/.github/workflows/release-artefacts.yml
@@ -27,17 +27,23 @@ jobs:
         include:
           - distro: debian
             image: debian:sid
-            artefact_glob: 'dist/thunderbolt-ibverbs-dkms_*.deb'
+            dkms_glob: 'dist/thunderbolt-ibverbs-dkms_*.deb'
+            rdma_glob: 'dist/usb4-rdma-provider_*.deb'
+            all_glob:  'dist/*.deb'
           - distro: fedora
             image: fedora:rawhide
-            artefact_glob: 'dist/thunderbolt-ibverbs-dkms-*.rpm'
+            dkms_glob: 'dist/thunderbolt-ibverbs-dkms-*.rpm'
+            rdma_glob: 'dist/usb4-rdma-provider-*.rpm'
+            all_glob:  'dist/*.rpm'
           - distro: arch
             image: archlinux:latest
-            artefact_glob: 'dist/thunderbolt-ibverbs-dkms-*.pkg.tar.zst'
+            dkms_glob: 'dist/thunderbolt-ibverbs-dkms-*.pkg.tar.zst'
+            rdma_glob: 'dist/usb4-rdma-provider-*.pkg.tar.zst'
+            all_glob:  'dist/*.pkg.tar.zst'
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build artefact in ${{ matrix.image }}
+      - name: Build DKMS package in ${{ matrix.image }}
         run: |
           mkdir -p dist
           docker run --rm \
@@ -46,21 +52,37 @@ jobs:
             -e TBV_LINT=1 \
             ${{ matrix.image }} \
             bash tools/ci/distro-package.sh ${{ matrix.distro }}
-          ls -la dist/
 
-      - name: Install + DKMS build verification in ${{ matrix.image }}
+      - name: Build rdma-provider package in ${{ matrix.image }}
         run: |
           docker run --rm \
             -v "$PWD:/work" \
             -w /work \
             ${{ matrix.image }} \
-            bash tools/ci/distro-install.sh '${{ matrix.artefact_glob }}'
+            bash tools/ci/distro-package-rdma.sh ${{ matrix.distro }}
+          ls -la dist/
 
-      - name: Upload artefact
+      - name: Verify DKMS install in ${{ matrix.image }}
+        run: |
+          docker run --rm \
+            -v "$PWD:/work" \
+            -w /work \
+            ${{ matrix.image }} \
+            bash tools/ci/distro-install.sh '${{ matrix.dkms_glob }}'
+
+      - name: Verify rdma-provider install in ${{ matrix.image }}
+        run: |
+          docker run --rm \
+            -v "$PWD:/work" \
+            -w /work \
+            ${{ matrix.image }} \
+            bash tools/ci/distro-install.sh '${{ matrix.rdma_glob }}'
+
+      - name: Upload artefacts
         uses: actions/upload-artifact@v4
         with:
           name: thunderbolt-ibverbs-${{ matrix.distro }}
-          path: ${{ matrix.artefact_glob }}
+          path: ${{ matrix.all_glob }}
           if-no-files-found: error
 
   release:

--- a/.github/workflows/release-artefacts.yml
+++ b/.github/workflows/release-artefacts.yml
@@ -1,0 +1,88 @@
+name: release-artefacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Attach artefacts to a GitHub Release. Run this workflow against a v* tag for this to take effect.'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    name: build (${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: debian
+            image: debian:sid
+            artefact_glob: 'dist/thunderbolt-ibverbs-dkms_*.deb'
+          - distro: fedora
+            image: fedora:rawhide
+            artefact_glob: 'dist/thunderbolt-ibverbs-dkms-*.rpm'
+          - distro: arch
+            image: archlinux:latest
+            artefact_glob: 'dist/thunderbolt-ibverbs-dkms-*.pkg.tar.zst'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build artefact in ${{ matrix.image }}
+        run: |
+          mkdir -p dist
+          docker run --rm \
+            -v "$PWD:/work" \
+            -w /work \
+            -e TBV_LINT=1 \
+            ${{ matrix.image }} \
+            bash tools/ci/distro-package.sh ${{ matrix.distro }}
+          ls -la dist/
+
+      - name: Install + DKMS build verification in ${{ matrix.image }}
+        run: |
+          docker run --rm \
+            -v "$PWD:/work" \
+            -w /work \
+            ${{ matrix.image }} \
+            bash tools/ci/distro-install.sh '${{ matrix.artefact_glob }}'
+
+      - name: Upload artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: thunderbolt-ibverbs-${{ matrix.distro }}
+          path: ${{ matrix.artefact_glob }}
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    if: ${{ inputs.publish && startsWith(github.ref, 'refs/tags/v') }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artefacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List collected artefacts
+        run: ls -la dist/
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" dist/* --clobber
+          else
+            gh release create "$tag" dist/* \
+              --title "$tag" \
+              --generate-notes
+          fi

--- a/.github/workflows/release-artefacts.yml
+++ b/.github/workflows/release-artefacts.yml
@@ -1,13 +1,21 @@
 name: release-artefacts
 
 on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
   workflow_dispatch:
     inputs:
       publish:
-        description: 'Attach artefacts to a GitHub Release. Run this workflow against a v* tag for this to take effect.'
+        description: 'When triggered manually against a v* tag, also create / update a GitHub Release.'
         required: false
         default: false
         type: boolean
+
+concurrency:
+  group: release-artefacts-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -57,7 +65,7 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    if: ${{ inputs.publish && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || inputs.publish) }}
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -39,17 +39,25 @@ Pre-built DKMS source packages are attached to GitHub Releases:
 
   https://github.com/hellas-ai/thunderbolt-ibverbs/releases
 
-Pick the artefact for your distro and install with the local package manager:
+Each release ships two packages per distro: the DKMS source package for the
+kernel module, and a userspace libibverbs provider so `ibv_devices` and
+downstream RDMA tools (NCCL, perftest, vllm) enumerate the device.
 
 ```sh
 # Debian or Ubuntu (needs Linux 6.14+)
-sudo apt install ./thunderbolt-ibverbs-dkms_<ver>_all.deb
+sudo apt install \
+    ./thunderbolt-ibverbs-dkms_<ver>_all.deb \
+    ./usb4-rdma-provider_<ver>_amd64.deb
 
 # Fedora
-sudo dnf install ./thunderbolt-ibverbs-dkms-<ver>-1.noarch.rpm
+sudo dnf install \
+    ./thunderbolt-ibverbs-dkms-<ver>-1.noarch.rpm \
+    ./usb4-rdma-provider-<ver>-1.x86_64.rpm
 
 # Arch
-sudo pacman -U ./thunderbolt-ibverbs-dkms-<ver>-1-any.pkg.tar.zst
+sudo pacman -U \
+    ./thunderbolt-ibverbs-dkms-<ver>-1-any.pkg.tar.zst \
+    ./usb4-rdma-provider-<ver>-1-x86_64.pkg.tar.zst
 ```
 
 DKMS builds the kernel module against your running kernel on install and

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ https://blog.hellas.ai/blog/thunderbolt-ibverbs/
 
 - Native Linux-to-Linux verbs transport is the main path.
 - Apple-compatible transport exists, but is still experimental.
-- The module builds against stock kernels.
+- The module builds against stock kernels, but needs Linux 6.14 or newer
+  (or this flake's `linux-thunderbolt` kernel) for the maintainer-tree
+  Thunderbolt/USB4 subsystem changes it relies on.
 - `nhi_interrupt_throttle_ns` is active only on kernels that export
   `tb_ring_throttling()`.
 - The Nix flake builds a Thunderbolt testing kernel from the maintainer
@@ -30,6 +32,29 @@ kernel sources and `MODULE_LICENSE("GPL")`.
 
 Small userspace-facing test and protocol helper files that say
 `GPL-2.0 OR BSD-3-Clause` may be used under either license.
+
+## Install From GitHub Releases
+
+Pre-built DKMS source packages are attached to GitHub Releases:
+
+  https://github.com/hellas-ai/thunderbolt-ibverbs/releases
+
+Pick the artefact for your distro and install with the local package manager:
+
+```sh
+# Debian or Ubuntu (needs Linux 6.14+)
+sudo apt install ./thunderbolt-ibverbs-dkms_<ver>_all.deb
+
+# Fedora
+sudo dnf install ./thunderbolt-ibverbs-dkms-<ver>-1.noarch.rpm
+
+# Arch
+sudo pacman -U ./thunderbolt-ibverbs-dkms-<ver>-1-any.pkg.tar.zst
+```
+
+DKMS builds the kernel module against your running kernel on install and
+rebuilds it after every kernel upgrade. Older kernels need the
+`linux-thunderbolt` build from this flake — see "Nix Thunderbolt Kernel" below.
 
 ## Requirements
 

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,7 @@
               packaging/test-rdma-patches.sh \
               tools/ci/distro-build.sh \
               tools/ci/distro-install.sh \
+              tools/ci/distro-package-rdma.sh \
               tools/ci/distro-package.sh \
               tools/ci/vm-guest-smoke.sh \
               tools/ci/vm-smoke.sh

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,8 @@
               packaging/regen-rdma-core-patches.sh \
               packaging/test-rdma-patches.sh \
               tools/ci/distro-build.sh \
+              tools/ci/distro-install.sh \
+              tools/ci/distro-package.sh \
               tools/ci/vm-guest-smoke.sh \
               tools/ci/vm-smoke.sh
             runHook postBuild
@@ -111,36 +113,6 @@
               tools/ci/proto-smoke.c \
               -o tbv-proto-smoke
             ./tbv-proto-smoke
-            runHook postBuild
-          '';
-
-          installPhase = ''
-            runHook preInstall
-            mkdir -p "$out"
-            runHook postInstall
-          '';
-        };
-      mkDockerDistroBuild = pkgs: { name, image }:
-        pkgs.stdenv.mkDerivation {
-          pname = "thunderbolt-ibverbs-distro-${name}";
-          version = "0.1.0";
-          src = ./.;
-
-          nativeBuildInputs = [
-            pkgs.bash
-            pkgs.docker-client
-          ];
-
-          requiredSystemFeatures = [ "docker" ];
-          __noChroot = true;
-          dontConfigure = true;
-
-          buildPhase = ''
-            runHook preBuild
-            export HOME="$TMPDIR/home"
-            mkdir -p "$HOME"
-            export DOCKER="${pkgs.docker-client}/bin/docker"
-            bash tools/ci/distro-build.sh ${lib.escapeShellArg image}
             runHook postBuild
           '';
 
@@ -248,20 +220,6 @@
           self.packages.${pkgs.stdenv.hostPlatform.system}.thunderbolt-ibverbs-linux-thunderbolt;
         checks = self.checks.${pkgs.stdenv.hostPlatform.system};
         vm-smoke.nixos = mkNixosVmSmoke pkgs;
-        distro = {
-          debian-sid = mkDockerDistroBuild pkgs {
-            name = "debian-sid";
-            image = "debian:sid";
-          };
-          fedora-rawhide = mkDockerDistroBuild pkgs {
-            name = "fedora-rawhide";
-            image = "fedora:rawhide";
-          };
-          archlinux-latest = mkDockerDistroBuild pkgs {
-            name = "archlinux-latest";
-            image = "archlinux:latest";
-          };
-        };
       });
 
       overlays.default = final: prev: {

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,19 @@
+# Maintainer: George Whewell <george@hellas.ai>
+pkgname=thunderbolt-ibverbs-dkms
+_modname=thunderbolt-ibverbs
+pkgver=@VERSION@
+pkgrel=1
+pkgdesc="Thunderbolt/USB4 host-to-host RDMA verbs kernel module (DKMS source)"
+arch=('any')
+url="https://github.com/hellas-ai/thunderbolt-ibverbs"
+license=('GPL-2.0-only')
+depends=('dkms' 'kmod')
+makedepends=()
+install="${pkgname}.install"
+source=("${_modname}-${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+package() {
+    install -dm0755 "${pkgdir}/usr/src/${_modname}-${pkgver}"
+    cp -a "${srcdir}/${_modname}-${pkgver}/." "${pkgdir}/usr/src/${_modname}-${pkgver}/"
+}

--- a/packaging/arch/PKGBUILD-rdma
+++ b/packaging/arch/PKGBUILD-rdma
@@ -1,0 +1,19 @@
+# Maintainer: George Whewell <george@hellas.ai>
+pkgname=usb4-rdma-provider
+pkgver=@VERSION@
+pkgrel=1
+pkgdesc="usb4_rdma libibverbs userspace provider"
+arch=('x86_64')
+url="https://github.com/hellas-ai/thunderbolt-ibverbs"
+license=('GPL-2.0-only')
+depends=('rdma-core')
+options=('!debug' '!strip')
+
+source=("@SONAME@" "usb4_rdma.driver")
+sha256sums=('SKIP' 'SKIP')
+
+package() {
+    install -Dm0644 "${srcdir}/@SONAME@" "${pkgdir}/usr/lib/libibverbs/@SONAME@"
+    install -Dm0644 "${srcdir}/usb4_rdma.driver" \
+        "${pkgdir}/etc/libibverbs.d/usb4_rdma.driver"
+}

--- a/packaging/arch/thunderbolt-ibverbs-dkms.install
+++ b/packaging/arch/thunderbolt-ibverbs-dkms.install
@@ -1,0 +1,19 @@
+_NAME=thunderbolt-ibverbs
+
+post_install() {
+    if command -v dkms >/dev/null 2>&1; then
+        dkms add -m "${_NAME}" -v "$1" >/dev/null 2>&1 || true
+        dkms autoinstall -m "${_NAME}/$1" >/dev/null 2>&1 || true
+    fi
+}
+
+post_upgrade() {
+    pre_remove "$2"
+    post_install "$1"
+}
+
+pre_remove() {
+    if command -v dkms >/dev/null 2>&1; then
+        dkms remove -m "${_NAME}" -v "$1" --all >/dev/null 2>&1 || true
+    fi
+}

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,0 +1,16 @@
+Package: thunderbolt-ibverbs-dkms
+Version: @VERSION@
+Section: kernel
+Priority: optional
+Architecture: all
+Depends: dkms (>= 2.1.0.0), kmod, libc6
+Maintainer: George Whewell <george@hellas.ai>
+Homepage: https://github.com/hellas-ai/thunderbolt-ibverbs
+Description: Thunderbolt/USB4 host-to-host RDMA verbs kernel module (DKMS source)
+ Experimental Linux kernel module exposing an RDMA verbs device over
+ Thunderbolt/USB4 host-to-host links. This package installs the module source
+ under /usr/src and registers it with DKMS, which builds the module against
+ the running kernel on install and on every subsequent kernel upgrade.
+ .
+ Requires Linux 6.14 or newer, or the linux-thunderbolt kernel built from
+ the upstream flake.

--- a/packaging/debian/control-rdma
+++ b/packaging/debian/control-rdma
@@ -1,0 +1,13 @@
+Package: usb4-rdma-provider
+Version: @VERSION@
+Section: libs
+Priority: optional
+Architecture: amd64
+Depends: libibverbs1
+Maintainer: George Whewell <george@hellas.ai>
+Homepage: https://github.com/hellas-ai/thunderbolt-ibverbs
+Description: usb4_rdma libibverbs userspace provider
+ Drop-in libibverbs provider that lets libibverbs enumerate and use
+ thunderbolt_ibverbs kernel devices. Install alongside the matching
+ thunderbolt-ibverbs-dkms package for full ibv_devices visibility and
+ downstream RDMA tool support (NCCL, vllm, perftest).

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+NAME=thunderbolt-ibverbs
+VERSION=@VERSION@
+
+case "$1" in
+    configure)
+        if command -v dkms >/dev/null 2>&1; then
+            if ! dkms status -m "$NAME" -v "$VERSION" 2>/dev/null | grep -q .; then
+                dkms add -m "$NAME" -v "$VERSION"
+            fi
+            dkms autoinstall -m "$NAME"/"$VERSION" || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+NAME=thunderbolt-ibverbs
+VERSION=@VERSION@
+
+case "$1" in
+    remove|upgrade|deconfigure)
+        if command -v dkms >/dev/null 2>&1; then
+            dkms remove -m "$NAME" -v "$VERSION" --all 2>/dev/null || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/packaging/rpm/thunderbolt-ibverbs-dkms.spec
+++ b/packaging/rpm/thunderbolt-ibverbs-dkms.spec
@@ -51,5 +51,5 @@ fi
 /usr/src/%{modname}-%{version}/*
 
 %changelog
-* Mon May 26 2026 George Whewell <george@hellas.ai> - 0.1.0-1
+* Tue May 26 2026 George Whewell <george@hellas.ai> - 0.1.0-1
 - Initial DKMS source package.

--- a/packaging/rpm/thunderbolt-ibverbs-dkms.spec
+++ b/packaging/rpm/thunderbolt-ibverbs-dkms.spec
@@ -1,0 +1,55 @@
+%global modname thunderbolt-ibverbs
+
+Name:           %{modname}-dkms
+Version:        @VERSION@
+Release:        1%{?dist}
+Summary:        Thunderbolt/USB4 host-to-host RDMA verbs kernel module (DKMS)
+
+License:        GPL-2.0-only
+URL:            https://github.com/hellas-ai/thunderbolt-ibverbs
+Source0:        %{modname}-%{version}.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  coreutils
+Requires:       dkms >= 2.1.0
+Requires:       kmod
+Requires(post): dkms
+Requires(preun): dkms
+
+%description
+Experimental Linux kernel module exposing an RDMA verbs device over
+Thunderbolt/USB4 host-to-host links. This package installs the module source
+under /usr/src and registers it with DKMS, which builds the module against the
+running kernel on install and on every subsequent kernel upgrade.
+
+Requires Linux 6.14 or newer, or the linux-thunderbolt kernel built from the
+upstream flake.
+
+%prep
+%setup -q -n %{modname}-%{version}
+
+%build
+# Source-only package; the kernel module is built on the target system by DKMS.
+
+%install
+install -d -m 0755 %{buildroot}/usr/src/%{modname}-%{version}
+cp -a . %{buildroot}/usr/src/%{modname}-%{version}/
+
+%post
+if [ "$1" = "1" ]; then
+    dkms add -m %{modname} -v %{version} >/dev/null 2>&1 || :
+fi
+dkms autoinstall -m %{modname}/%{version} >/dev/null 2>&1 || :
+
+%preun
+if [ "$1" = "0" ]; then
+    dkms remove -m %{modname} -v %{version} --all >/dev/null 2>&1 || :
+fi
+
+%files
+%dir /usr/src/%{modname}-%{version}
+/usr/src/%{modname}-%{version}/*
+
+%changelog
+* Mon May 26 2026 George Whewell <george@hellas.ai> - 0.1.0-1
+- Initial DKMS source package.

--- a/packaging/rpm/usb4-rdma-provider.spec
+++ b/packaging/rpm/usb4-rdma-provider.spec
@@ -1,0 +1,33 @@
+%global provider_lib_dir /usr/lib64/libibverbs
+%global provider_etc_dir /etc/libibverbs.d
+
+Name:           usb4-rdma-provider
+Version:        @VERSION@
+Release:        1%{?dist}
+Summary:        usb4_rdma libibverbs userspace provider
+
+License:        GPL-2.0-only OR BSD-3-Clause
+URL:            https://github.com/hellas-ai/thunderbolt-ibverbs
+
+BuildArch:      x86_64
+Requires:       libibverbs
+
+%description
+Drop-in libibverbs provider that lets libibverbs enumerate and use
+thunderbolt_ibverbs kernel devices. Install alongside the matching
+thunderbolt-ibverbs-dkms package for full ibv_devices visibility and
+downstream RDMA tool support (NCCL, vllm, perftest).
+
+%install
+install -d -m 0755 %{buildroot}%{provider_lib_dir}
+install -d -m 0755 %{buildroot}%{provider_etc_dir}
+install -m 0644 %{_sourcedir}/libusb4_rdma-rdmav*.so %{buildroot}%{provider_lib_dir}/
+install -m 0644 %{_sourcedir}/usb4_rdma.driver %{buildroot}%{provider_etc_dir}/
+
+%files
+%{provider_lib_dir}/libusb4_rdma-rdmav*.so
+%{provider_etc_dir}/usb4_rdma.driver
+
+%changelog
+* Tue May 26 2026 George Whewell <george@hellas.ai> - 0.1.0-1
+- Initial release.

--- a/tools/ci/distro-install.sh
+++ b/tools/ci/distro-install.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
-# Install a DKMS source package built by tools/ci/distro-package.sh and verify
-# DKMS can build the module against the distro's packaged kernel-headers. Does
-# NOT load the module — that needs a real distro kernel and lives in
-# tools/ci/vm-smoke.sh.
+# Install a thunderbolt-ibverbs-dkms or usb4-rdma-provider package built by the
+# matching distro-package*.sh script. Verifies:
+#
+#   thunderbolt-ibverbs-dkms   — DKMS can build the module against the distro's
+#                                packaged kernel-headers.
+#   usb4-rdma-provider         — provider .so is installed at the expected path,
+#                                its dynamic deps resolve, and libibverbs does
+#                                not crash when its driver hint is present.
+#
+# Does NOT load the kernel module — that needs a real distro kernel and lives
+# in tools/ci/vm-smoke.sh.
 
 set -euo pipefail
 
@@ -11,9 +18,9 @@ usage() {
 Usage:
   tools/ci/distro-install.sh <artefact-path-or-glob>
 
-Detects the distro from the artefact extension (.deb, .rpm, .pkg.tar.zst).
-Installs the package, then runs `dkms build` against the latest packaged
-kernel-headers. Verifies thunderbolt_ibverbs.ko is produced.
+Detects the package type from the artefact filename
+(thunderbolt-ibverbs-dkms or usb4-rdma-provider) and runs the appropriate
+verification flow.
 EOF
 }
 
@@ -42,7 +49,16 @@ fi
 artefact="$(realpath "${artefacts[0]}")"
 [[ -f "$artefact" ]] || { printf 'error: not a file: %s\n' "$artefact" >&2; exit 1; }
 
-install_deps() {
+case "$(basename "$artefact")" in
+	thunderbolt-ibverbs-dkms*) pkg_kind="dkms" ;;
+	usb4-rdma-provider*)       pkg_kind="rdma-provider" ;;
+	*)
+		printf 'error: unknown package name in %s\n' "$artefact" >&2
+		exit 1
+		;;
+esac
+
+install_dkms_deps() {
 	if command -v apt-get >/dev/null 2>&1; then
 		export DEBIAN_FRONTEND=noninteractive
 		apt-get update -qq
@@ -61,6 +77,43 @@ install_deps() {
 		cat /etc/os-release >&2 || true
 		exit 1
 	fi
+}
+
+install_provider_deps() {
+	if command -v apt-get >/dev/null 2>&1; then
+		export DEBIAN_FRONTEND=noninteractive
+		apt-get update -qq
+		apt-get install -y -qq --no-install-recommends \
+			ca-certificates file ibverbs-providers ibverbs-utils libibverbs1
+	elif command -v dnf >/dev/null 2>&1; then
+		dnf install -y -q --setopt=install_weak_deps=False \
+			ca-certificates file libibverbs libibverbs-utils
+	elif command -v pacman >/dev/null 2>&1; then
+		pacman -Syu --noconfirm --needed \
+			ca-certificates file rdma-core
+	else
+		printf 'error: unsupported distro\n' >&2
+		cat /etc/os-release >&2 || true
+		exit 1
+	fi
+}
+
+install_package() {
+	case "$artefact" in
+	*.deb)
+		DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$artefact"
+		;;
+	*.rpm)
+		dnf install -y "$artefact"
+		;;
+	*.pkg.tar.zst|*.pkg.tar.xz)
+		pacman -U --noconfirm "$artefact"
+		;;
+	*)
+		printf 'error: unsupported artefact extension: %s\n' "$artefact" >&2
+		exit 1
+		;;
+	esac
 }
 
 find_dkms_kver() {
@@ -82,51 +135,90 @@ find_dkms_kver() {
 	printf '%s\n' "$kver"
 }
 
-install_package() {
-	case "$artefact" in
-	*.deb)
-		DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$artefact"
-		;;
-	*.rpm)
-		dnf install -y "$artefact"
-		;;
-	*.pkg.tar.zst|*.pkg.tar.xz)
-		pacman -U --noconfirm "$artefact"
-		;;
-	*)
-		printf 'error: unsupported artefact extension: %s\n' "$artefact" >&2
+verify_dkms() {
+	install_dkms_deps
+	install_package
+
+	local modname=thunderbolt-ibverbs
+	local src_dir
+	src_dir="$(find /usr/src -maxdepth 1 -type d -name "${modname}-*" -print -quit)"
+	[[ -n "$src_dir" ]] ||
+		{ printf 'error: %s source not under /usr/src after install\n' "$modname" >&2; exit 1; }
+	local version
+	version="$(awk -F'"' '/^PACKAGE_VERSION=/ { print $2; exit }' "$src_dir/dkms.conf")"
+
+	local kver
+	kver="$(find_dkms_kver)"
+
+	printf '==> Source dir: %s\n' "$src_dir"
+	printf '==> Version:    %s\n' "$version"
+	printf '==> Kernel:     %s\n' "$kver"
+
+	dkms status -m "$modname" -v "$version" || true
+
+	if ! dkms build -m "$modname" -v "$version" -k "$kver" --force; then
+		cat "/var/lib/dkms/$modname/$version/build/make.log" >&2 || true
 		exit 1
-		;;
-	esac
+	fi
+
+	local built
+	built="$(find "/var/lib/dkms/$modname/$version" -name 'thunderbolt_ibverbs.ko' -print -quit)"
+	[[ -n "$built" ]] ||
+		{ printf 'error: dkms build did not produce thunderbolt_ibverbs.ko\n' >&2; exit 1; }
+
+	file "$built"
+	modinfo "$built" | sed -n '1,20p'
+
+	printf '==> DKMS install verification OK\n'
 }
 
-install_deps
-install_package
+verify_provider() {
+	install_provider_deps
+	install_package
 
-modname=thunderbolt-ibverbs
-src_dir="$(find /usr/src -maxdepth 1 -type d -name "${modname}-*" -print -quit)"
-[[ -n "$src_dir" ]] ||
-	{ printf 'error: %s source not under /usr/src after install\n' "$modname" >&2; exit 1; }
-version="$(awk -F'"' '/^PACKAGE_VERSION=/ { print $2; exit }' "$src_dir/dkms.conf")"
+	local driver="/etc/libibverbs.d/usb4_rdma.driver"
+	[[ -f "$driver" ]] ||
+		{ printf 'error: driver hint missing at %s\n' "$driver" >&2; exit 1; }
 
-kver="$(find_dkms_kver)"
+	printf '==> Driver hint: %s\n' "$driver"
+	cat "$driver"
 
-printf '==> Source dir: %s\n' "$src_dir"
-printf '==> Version:    %s\n' "$version"
-printf '==> Kernel:     %s\n' "$kver"
+	local so=""
+	for d in /usr/lib/x86_64-linux-gnu/libibverbs /usr/lib64/libibverbs /usr/lib/libibverbs; do
+		[[ -d "$d" ]] || continue
+		so="$(find "$d" -maxdepth 1 -name 'libusb4_rdma-rdmav*.so' -print -quit)"
+		[[ -n "$so" ]] && break
+	done
+	[[ -n "$so" ]] ||
+		{ printf 'error: provider .so not found in any libibverbs dir\n' >&2; exit 1; }
 
-dkms status -m "$modname" -v "$version" || true
+	printf '==> Provider .so: %s\n' "$so"
+	file "$so"
 
-if ! dkms build -m "$modname" -v "$version" -k "$kver" --force; then
-	cat "/var/lib/dkms/$modname/$version/build/make.log" >&2 || true
-	exit 1
-fi
+	printf '==> ldd lib resolution\n'
+	if ldd "$so" 2>&1 | grep -E 'not found'; then
+		printf 'error: unresolved dynamic library\n' >&2
+		exit 1
+	fi
+	ldd "$so" | sed -n '1,12p'
 
-built="$(find "/var/lib/dkms/$modname/$version" -name 'thunderbolt_ibverbs.ko' -print -quit)"
-[[ -n "$built" ]] ||
-	{ printf 'error: dkms build did not produce thunderbolt_ibverbs.ko\n' >&2; exit 1; }
+	# ldd -r performs relocations and reports missing function references.
+	# Catches PABI mismatches (e.g. wrong verbs_register_driver_<N> version)
+	# and missing imports — without needing an actual /sys/class/infiniband
+	# device for libibverbs to match against.
+	printf '==> ldd -r symbol resolution\n'
+	if ldd -r "$so" 2>&1 | grep -E 'undefined symbol'; then
+		printf 'error: unresolved symbols in provider .so\n' >&2
+		exit 1
+	fi
 
-file "$built"
-modinfo "$built" | sed -n '1,20p'
+	printf '==> ibv_devices smoke\n'
+	ibv_devices
 
-printf '==> install verification OK\n'
+	printf '==> provider install verification OK\n'
+}
+
+case "$pkg_kind" in
+	dkms)          verify_dkms ;;
+	rdma-provider) verify_provider ;;
+esac

--- a/tools/ci/distro-install.sh
+++ b/tools/ci/distro-install.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Install a DKMS source package built by tools/ci/distro-package.sh and verify
+# DKMS can build the module against the distro's packaged kernel-headers. Does
+# NOT load the module — that needs a real distro kernel and lives in
+# tools/ci/vm-smoke.sh.
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage:
+  tools/ci/distro-install.sh <artefact-path-or-glob>
+
+Detects the distro from the artefact extension (.deb, .rpm, .pkg.tar.zst).
+Installs the package, then runs `dkms build` against the latest packaged
+kernel-headers. Verifies thunderbolt_ibverbs.ko is produced.
+EOF
+}
+
+target="${1:-}"
+case "${target:-}" in
+	-h|--help) usage; exit 0 ;;
+	"") usage >&2; exit 1 ;;
+esac
+
+shopt -s nullglob
+# shellcheck disable=SC2206
+artefacts=( $target )
+shopt -u nullglob
+if [[ ${#artefacts[@]} -eq 0 ]]; then
+	if [[ -f "$target" ]]; then
+		artefacts=( "$target" )
+	else
+		printf 'error: no artefact matched: %s\n' "$target" >&2
+		exit 1
+	fi
+fi
+if [[ ${#artefacts[@]} -gt 1 ]]; then
+	printf 'error: multiple artefacts matched: %s\n' "${artefacts[*]}" >&2
+	exit 1
+fi
+artefact="$(realpath "${artefacts[0]}")"
+[[ -f "$artefact" ]] || { printf 'error: not a file: %s\n' "$artefact" >&2; exit 1; }
+
+install_deps() {
+	if command -v apt-get >/dev/null 2>&1; then
+		export DEBIAN_FRONTEND=noninteractive
+		apt-get update -qq
+		apt-get install -y -qq --no-install-recommends \
+			build-essential ca-certificates dkms file kmod \
+			linux-headers-amd64 make
+	elif command -v dnf >/dev/null 2>&1; then
+		dnf install -y -q --setopt=install_weak_deps=False \
+			ca-certificates dkms diffutils file gcc kernel-devel \
+			kernel-headers kmod make openssl
+	elif command -v pacman >/dev/null 2>&1; then
+		pacman -Syu --noconfirm --needed \
+			base-devel ca-certificates dkms file kmod linux-headers make
+	else
+		printf 'error: unsupported distro\n' >&2
+		cat /etc/os-release >&2 || true
+		exit 1
+	fi
+}
+
+find_dkms_kver() {
+	local kver=""
+	if [[ -d /usr/src/kernels ]]; then
+		kver="$(find /usr/src/kernels -mindepth 1 -maxdepth 1 -type d \
+			-printf '%f\n' | sort -V | tail -n 1)"
+		if [[ -n "$kver" && ! -e "/lib/modules/$kver/build" ]]; then
+			mkdir -p "/lib/modules/$kver"
+			ln -s "/usr/src/kernels/$kver" "/lib/modules/$kver/build"
+		fi
+	fi
+	if [[ -z "$kver" && -d /lib/modules ]]; then
+		kver="$(find /lib/modules -mindepth 1 -maxdepth 1 -type d \
+			-printf '%f\n' | sort -V | tail -n 1)"
+	fi
+	[[ -n "$kver" && -d "/lib/modules/$kver/build" ]] ||
+		{ printf 'error: no kernel headers found under /lib/modules/*/build\n' >&2; exit 1; }
+	printf '%s\n' "$kver"
+}
+
+install_package() {
+	case "$artefact" in
+	*.deb)
+		DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$artefact"
+		;;
+	*.rpm)
+		dnf install -y "$artefact"
+		;;
+	*.pkg.tar.zst|*.pkg.tar.xz)
+		pacman -U --noconfirm "$artefact"
+		;;
+	*)
+		printf 'error: unsupported artefact extension: %s\n' "$artefact" >&2
+		exit 1
+		;;
+	esac
+}
+
+install_deps
+install_package
+
+modname=thunderbolt-ibverbs
+src_dir="$(find /usr/src -maxdepth 1 -type d -name "${modname}-*" -print -quit)"
+[[ -n "$src_dir" ]] ||
+	{ printf 'error: %s source not under /usr/src after install\n' "$modname" >&2; exit 1; }
+version="$(awk -F'"' '/^PACKAGE_VERSION=/ { print $2; exit }' "$src_dir/dkms.conf")"
+
+kver="$(find_dkms_kver)"
+
+printf '==> Source dir: %s\n' "$src_dir"
+printf '==> Version:    %s\n' "$version"
+printf '==> Kernel:     %s\n' "$kver"
+
+dkms status -m "$modname" -v "$version" || true
+
+if ! dkms build -m "$modname" -v "$version" -k "$kver" --force; then
+	cat "/var/lib/dkms/$modname/$version/build/make.log" >&2 || true
+	exit 1
+fi
+
+built="$(find "/var/lib/dkms/$modname/$version" -name 'thunderbolt_ibverbs.ko' -print -quit)"
+[[ -n "$built" ]] ||
+	{ printf 'error: dkms build did not produce thunderbolt_ibverbs.ko\n' >&2; exit 1; }
+
+file "$built"
+modinfo "$built" | sed -n '1,20p'
+
+printf '==> install verification OK\n'

--- a/tools/ci/distro-package-rdma.sh
+++ b/tools/ci/distro-package-rdma.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Build the usb4_rdma libibverbs userspace provider by applying our patches to
+# rdma-core upstream, building with CMake/Ninja inside the target distro
+# container, then packaging the resulting .so + driver hint as a native
+# .deb/.rpm/.pkg.tar.zst. Building inside each distro's container gives a
+# provider .so whose libibverbs PABI version matches that distro's libibverbs.
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage:
+  tools/ci/distro-package-rdma.sh debian|fedora|arch
+
+Outputs the produced .deb / .rpm / .pkg.tar.zst into OUT_DIR.
+
+Environment:
+  TBV_VERSION       Override version (default reads PACKAGE_VERSION from dkms.conf).
+  OUT_DIR           Output directory (default $PWD/dist).
+  WORK_DIR          Scratch directory (default mktemp).
+  RDMA_CORE_TAG     rdma-core git tag to build against (default v62.0).
+  TBV_SKIP_DEPS     Skip distro deps install (default 0).
+  TBV_SKIP_BUILD    Skip the rdma-core build step (used by the arch builder
+                    re-exec; default 0).
+EOF
+}
+
+distro="${1:-}"
+case "${distro:-}" in
+	-h|--help) usage; exit 0 ;;
+	debian|fedora|arch) ;;
+	"") usage >&2; exit 1 ;;
+	*) printf 'error: unsupported distro: %s\n' "$distro" >&2; exit 1 ;;
+esac
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+version="${TBV_VERSION:-$(awk -F'"' '/^PACKAGE_VERSION=/ { print $2; exit }' "$repo_root/dkms.conf")}"
+[[ -n "$version" ]] || { printf 'error: could not determine version\n' >&2; exit 1; }
+out_dir="${OUT_DIR:-$repo_root/dist}"
+work_dir="${WORK_DIR:-$(mktemp -d)}"
+rdma_core_tag="${RDMA_CORE_TAG:-v62.0}"
+skip_deps="${TBV_SKIP_DEPS:-0}"
+skip_build="${TBV_SKIP_BUILD:-0}"
+pkgname="usb4-rdma-provider"
+
+mkdir -p "$out_dir" "$work_dir"
+
+install_deps() {
+	[[ "$skip_deps" == "1" ]] && return 0
+	case "$distro" in
+		debian)
+			export DEBIAN_FRONTEND=noninteractive
+			apt-get update -qq
+			apt-get install -y -qq --no-install-recommends \
+				build-essential ca-certificates cmake dpkg-dev \
+				git libcap-dev libnl-3-dev libnl-route-3-dev libsystemd-dev \
+				libudev-dev libssl-dev ninja-build patch patchelf pkg-config \
+				python3-docutils python3-pyelftools
+			;;
+		fedora)
+			dnf install -y -q --setopt=install_weak_deps=False \
+				cmake gcc gcc-c++ git libcap-devel libnl3-devel libudev-devel \
+				make ninja-build openssl-devel patch patchelf pkgconf rpm-build \
+				python3-docutils python3-pyelftools systemd-devel tar
+			;;
+		arch)
+			pacman -Sy --noconfirm --needed \
+				base-devel ca-certificates cmake git libnl ninja patch \
+				patchelf python-docutils python-pyelftools sudo systemd
+			;;
+	esac
+}
+
+build_provider() {
+	[[ "$skip_build" == "1" ]] && return 0
+	local src="$work_dir/rdma-core"
+	local build="$src/build"
+
+	if [[ ! -d "$src" ]]; then
+		git clone --depth 1 --branch "$rdma_core_tag" \
+			https://github.com/linux-rdma/rdma-core "$src"
+	fi
+
+	for p in "$repo_root/packaging/rdma-core-patches"/*.patch; do
+		( cd "$src" && patch --silent -p1 < "$p" )
+	done
+
+	rm -rf "$build"
+	mkdir "$build"
+	( cd "$build" && cmake -GNinja -DNO_PYVERBS=1 .. >/dev/null && ninja )
+
+	local so
+	so="$(find "$build/lib" -maxdepth 1 -name 'libusb4_rdma-rdmav*.so' -print -quit)"
+	[[ -n "$so" ]] || { printf 'error: provider .so not produced\n' >&2; exit 1; }
+
+	# CMake embeds the build dir as RUNPATH so libibverbs can run from the
+	# build tree without installing. For packaging we want a clean .so with no
+	# build-host paths leaked — strip the RUNPATH.
+	patchelf --remove-rpath "$so"
+
+	printf '==> Built provider: %s\n' "$(basename "$so")"
+}
+
+stage_provider_files() {
+	local stage="$1"
+	local src="$work_dir/rdma-core"
+	local build="$src/build"
+
+	install -d -m 0755 "$stage"
+
+	local so
+	so="$(find "$build/lib" -maxdepth 1 -name 'libusb4_rdma-rdmav*.so' -print -quit)"
+	[[ -n "$so" ]] || { printf 'error: provider .so not in build tree\n' >&2; exit 1; }
+
+	cp "$so" "$stage/"
+	# The .driver file emitted by rdma-core's build tree embeds the absolute
+	# build-tree path so libibverbs can run from the build dir without install.
+	# For packaging, write the plain installed-tree form: `driver <name>`.
+	printf 'driver usb4_rdma\n' > "$stage/usb4_rdma.driver"
+}
+
+substitute() {
+	sed "s/@VERSION@/${version}/g" "$1" > "$2"
+}
+
+build_deb() {
+	local arch
+	arch="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
+	local deb_stage="$work_dir/deb"
+	rm -rf "$deb_stage"
+	install -d -m 0755 "$deb_stage/DEBIAN"
+	install -d -m 0755 "$deb_stage/usr/lib/$arch/libibverbs"
+	install -d -m 0755 "$deb_stage/etc/libibverbs.d"
+
+	local files="$work_dir/files"
+	stage_provider_files "$files"
+
+	install -m 0644 "$files"/libusb4_rdma-rdmav*.so \
+		"$deb_stage/usr/lib/$arch/libibverbs/"
+	install -m 0644 "$files/usb4_rdma.driver" \
+		"$deb_stage/etc/libibverbs.d/usb4_rdma.driver"
+
+	substitute "$repo_root/packaging/debian/control-rdma" "$deb_stage/DEBIAN/control"
+
+	local deb="$out_dir/${pkgname}_${version}_amd64.deb"
+	dpkg-deb --root-owner-group --build "$deb_stage" "$deb" >/dev/null
+	printf '==> Built %s\n' "$deb"
+}
+
+build_rpm() {
+	local rpm_top="$work_dir/rpmbuild"
+	rm -rf "$rpm_top"
+	install -d -m 0755 "$rpm_top"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+	stage_provider_files "$rpm_top/SOURCES"
+
+	substitute "$repo_root/packaging/rpm/${pkgname}.spec" \
+		"$rpm_top/SPECS/${pkgname}.spec"
+
+	rpmbuild --define "_topdir $rpm_top" -bb \
+		"$rpm_top/SPECS/${pkgname}.spec"
+
+	local rpm
+	rpm="$(find "$rpm_top/RPMS" -name '*.rpm' -print -quit)"
+	[[ -n "$rpm" ]] || { printf 'error: rpmbuild produced no .rpm\n' >&2; exit 1; }
+
+	cp "$rpm" "$out_dir/"
+	printf '==> Built %s\n' "$out_dir/$(basename "$rpm")"
+}
+
+build_arch_as_builder() {
+	local stage="$work_dir/arch"
+	rm -rf "$stage"
+	install -d -m 0755 "$stage"
+
+	stage_provider_files "$stage"
+
+	local soname
+	soname="$(basename "$(find "$stage" -name 'libusb4_rdma-rdmav*.so' -print -quit)")"
+	[[ -n "$soname" ]] || { printf 'error: staged .so missing\n' >&2; exit 1; }
+
+	sed -e "s/@VERSION@/${version}/g" -e "s/@SONAME@/${soname}/g" \
+		"$repo_root/packaging/arch/PKGBUILD-rdma" > "$stage/PKGBUILD"
+
+	( cd "$stage" && makepkg --noconfirm --skipchecksums --nodeps )
+
+	local pkg
+	pkg="$(find "$stage" -maxdepth 1 -name "${pkgname}-[0-9]*.pkg.tar.zst" -print -quit)"
+	[[ -n "$pkg" ]] || { printf 'error: makepkg produced no main package\n' >&2; exit 1; }
+
+	cp "$pkg" "$out_dir/"
+	printf '==> Built %s\n' "$out_dir/$(basename "$pkg")"
+}
+
+build_arch() {
+	# makepkg refuses to run as root. Build rdma-core as root (above), then
+	# re-exec as a builder user for the packaging step.
+	if [[ "$(id -u)" -eq 0 ]]; then
+		id -u builder >/dev/null 2>&1 || useradd -m -s /bin/bash builder
+		chown -R builder:builder "$work_dir" "$out_dir"
+		exec sudo -u builder \
+			env TBV_VERSION="$version" OUT_DIR="$out_dir" \
+				WORK_DIR="$work_dir" RDMA_CORE_TAG="$rdma_core_tag" \
+				TBV_SKIP_DEPS=1 TBV_SKIP_BUILD=1 \
+			bash "$0" "$distro"
+	fi
+	build_arch_as_builder
+}
+
+install_deps
+build_provider
+
+case "$distro" in
+	debian) build_deb ;;
+	fedora) build_rpm ;;
+	arch)   build_arch ;;
+esac

--- a/tools/ci/distro-package.sh
+++ b/tools/ci/distro-package.sh
@@ -72,7 +72,6 @@ stage_source() {
 		Makefile \
 		dkms.conf \
 		LICENSE \
-		LICENSES \
 		README.md \
 		kernel \
 		proto \

--- a/tools/ci/distro-package.sh
+++ b/tools/ci/distro-package.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Build a DKMS source package for the given distro using the distro's native
+# packaging tooling. Run inside a container that matches the target distro
+# (debian:sid, fedora:rawhide, archlinux:latest). The script installs the
+# build dependencies it needs.
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage:
+  tools/ci/distro-package.sh debian|fedora|arch
+
+Outputs the produced .deb / .rpm / .pkg.tar.zst into OUT_DIR.
+
+Environment:
+  TBV_VERSION     Override package version. Defaults to PACKAGE_VERSION read
+                  from dkms.conf.
+  OUT_DIR         Output directory. Defaults to $(pwd)/dist.
+  WORK_DIR        Scratch directory. Defaults to a fresh mktemp dir.
+  TBV_LINT        Run lintian / rpmlint / namcap on the artefact. 1 to enable.
+                  Defaults to 0.
+  TBV_SKIP_DEPS   Skip the distro deps install step. 1 to skip. Useful for
+                  local dev when deps are already present.
+EOF
+}
+
+distro="${1:-}"
+case "${distro:-}" in
+	-h|--help) usage; exit 0 ;;
+	debian|fedora|arch) ;;
+	"") usage >&2; exit 1 ;;
+	*) printf 'error: unsupported distro: %s\n' "$distro" >&2; exit 1 ;;
+esac
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+version="${TBV_VERSION:-$(awk -F'"' '/^PACKAGE_VERSION=/ { print $2; exit }' "$repo_root/dkms.conf")}"
+[[ -n "$version" ]] || { printf 'error: could not determine version from dkms.conf\n' >&2; exit 1; }
+out_dir="${OUT_DIR:-$repo_root/dist}"
+work_dir="${WORK_DIR:-$(mktemp -d)}"
+lint="${TBV_LINT:-0}"
+skip_deps="${TBV_SKIP_DEPS:-0}"
+modname="thunderbolt-ibverbs"
+pkgname="${modname}-dkms"
+
+mkdir -p "$out_dir" "$work_dir"
+
+install_deps() {
+	[[ "$skip_deps" == "1" ]] && return 0
+	case "$distro" in
+		debian)
+			export DEBIAN_FRONTEND=noninteractive
+			apt-get update -qq
+			apt-get install -y -qq --no-install-recommends \
+				ca-certificates dpkg-dev fakeroot lintian
+			;;
+		fedora)
+			dnf install -y -q --setopt=install_weak_deps=False \
+				ca-certificates coreutils rpm-build rpmlint tar
+			;;
+		arch)
+			pacman -Sy --noconfirm --needed \
+				base-devel ca-certificates dkms namcap sudo
+			;;
+	esac
+}
+
+stage_source() {
+	local stage="$1"
+	install -d -m 0755 "$stage"
+	tar -C "$repo_root" -cf - \
+		Makefile \
+		dkms.conf \
+		LICENSE \
+		LICENSES \
+		README.md \
+		kernel \
+		proto \
+		| tar -C "$stage" -xf -
+}
+
+make_source_tarball() {
+	local top="$work_dir/${modname}-${version}"
+	rm -rf "$top"
+	stage_source "$top"
+	tar -C "$work_dir" -czf "$work_dir/${modname}-${version}.tar.gz" \
+		"${modname}-${version}"
+	printf '%s\n' "$work_dir/${modname}-${version}.tar.gz"
+}
+
+substitute() {
+	sed "s/@VERSION@/${version}/g" "$1" > "$2"
+}
+
+build_deb() {
+	local stage="$work_dir/deb"
+	rm -rf "$stage"
+	install -d -m 0755 "$stage/DEBIAN"
+	stage_source "$stage/usr/src/${modname}-${version}"
+
+	substitute "$repo_root/packaging/debian/control" "$stage/DEBIAN/control"
+	substitute "$repo_root/packaging/debian/postinst" "$stage/DEBIAN/postinst"
+	substitute "$repo_root/packaging/debian/prerm" "$stage/DEBIAN/prerm"
+	chmod 0755 "$stage/DEBIAN/postinst" "$stage/DEBIAN/prerm"
+
+	local deb="$out_dir/${pkgname}_${version}_all.deb"
+	dpkg-deb --root-owner-group --build "$stage" "$deb" >/dev/null
+	printf '==> Built %s\n' "$deb"
+
+	if [[ "$lint" == "1" ]] && command -v lintian >/dev/null 2>&1; then
+		printf '==> lintian\n'
+		lintian --no-tag-display-limit \
+			--suppress-tags no-changelog,no-manual-page,no-copyright-file,extended-description-is-probably-too-short,initial-upload-closes-no-bugs,debian-changelog-file-missing \
+			"$deb" || true
+	fi
+}
+
+build_rpm() {
+	local rpm_top="$work_dir/rpmbuild"
+	rm -rf "$rpm_top"
+	install -d -m 0755 "$rpm_top"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+	local tarball
+	tarball="$(make_source_tarball)"
+	cp "$tarball" "$rpm_top/SOURCES/"
+
+	substitute "$repo_root/packaging/rpm/${pkgname}.spec" "$rpm_top/SPECS/${pkgname}.spec"
+
+	rpmbuild --define "_topdir $rpm_top" -bb "$rpm_top/SPECS/${pkgname}.spec"
+
+	local rpm
+	rpm="$(find "$rpm_top/RPMS" -name '*.rpm' -print -quit)"
+	[[ -n "$rpm" ]] || { printf 'error: rpmbuild produced no .rpm\n' >&2; exit 1; }
+
+	cp "$rpm" "$out_dir/"
+	printf '==> Built %s\n' "$out_dir/$(basename "$rpm")"
+
+	if [[ "$lint" == "1" ]] && command -v rpmlint >/dev/null 2>&1; then
+		printf '==> rpmlint\n'
+		rpmlint "$out_dir/$(basename "$rpm")" || true
+	fi
+}
+
+build_arch_as_builder() {
+	local stage="$work_dir/arch"
+	rm -rf "$stage"
+	install -d -m 0755 "$stage"
+
+	local tarball
+	tarball="$(make_source_tarball)"
+	cp "$tarball" "$stage/"
+
+	substitute "$repo_root/packaging/arch/PKGBUILD" "$stage/PKGBUILD"
+	cp "$repo_root/packaging/arch/${pkgname}.install" "$stage/"
+
+	( cd "$stage" && makepkg --noconfirm --skipchecksums )
+
+	local pkg
+	pkg="$(find "$stage" -name '*.pkg.tar.zst' -print -quit)"
+	[[ -n "$pkg" ]] || { printf 'error: makepkg produced no package\n' >&2; exit 1; }
+
+	cp "$pkg" "$out_dir/"
+	printf '==> Built %s\n' "$out_dir/$(basename "$pkg")"
+
+	if [[ "$lint" == "1" ]] && command -v namcap >/dev/null 2>&1; then
+		printf '==> namcap\n'
+		namcap "$out_dir/$(basename "$pkg")" || true
+	fi
+}
+
+build_arch() {
+	# makepkg refuses to run as root. If we are root, create a builder user
+	# and re-exec this script as that user.
+	if [[ "$(id -u)" -eq 0 ]]; then
+		id -u builder >/dev/null 2>&1 || useradd -m -s /bin/bash builder
+		chown -R builder:builder "$work_dir" "$out_dir"
+		exec sudo -u builder \
+			env TBV_VERSION="$version" OUT_DIR="$out_dir" \
+				WORK_DIR="$work_dir" TBV_LINT="$lint" \
+				TBV_SKIP_DEPS=1 \
+			bash "$0" "$distro"
+	fi
+	build_arch_as_builder
+}
+
+install_deps
+
+case "$distro" in
+	debian) build_deb ;;
+	fedora) build_rpm ;;
+	arch)   build_arch ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-artefacts.yml` that builds two packages per distro using each distro's native tooling: `thunderbolt-ibverbs-dkms` (kernel module DKMS source) and `usb4-rdma-provider` (userspace libibverbs provider for `ibv_devices` enumeration / NCCL / perftest / vllm compatibility).
- Matrix: `debian:sid` → `.deb`, `fedora:rawhide` → `.rpm`, `archlinux:latest` → `.pkg.tar.zst`.
- Workflow runs on PRs and `main` pushes (build-only) and on `v*` tag pushes (auto-publish to GitHub Releases with `gh release create`).
- Drops `mkDockerDistroBuild` from `hydraJobs` — Hydra keeps owning Nix-flake correctness, distro artefact production moves to GH Actions where the native toolchains live.
- README updated with install commands pointing at the Releases page.

## Test plan

Locally verified all six artefacts end-to-end inside their respective containers:

- [x] `debian:sid`: DKMS package builds → installs → `dkms build` against `linux-headers-amd64` succeeds → `.ko` signed. Provider package builds → installs → `ldd -r` resolves all symbols → `ibv_devices` runs cleanly.
- [x] `fedora:rawhide`: same flow against `kernel-devel` and `libibverbs` (PABI 59).
- [x] `archlinux:latest`: same flow against `linux-headers` and `rdma-core` (PABI 59).

## Notes for reviewer

- Provider `.so` is built from upstream rdma-core v62.0 + the three patches at `packaging/rdma-core-patches/`. `patchelf --remove-rpath` strips the CMake build-tree RUNPATH so rpmbuild's check-rpaths passes.
- Provider PABI version is taken from each distro's libibverbs (currently all converge to 59). If we ever need to support older distros we can add more matrix entries.
- Module-load testing in a real distro VM is still a follow-up (existing `tools/ci/vm-smoke.sh` does it from source; could be extended to install from package).