### PR TITLE
nix: build perftest + bench-tools on aarch64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,11 +14,17 @@
     let
       lib = nixpkgs.lib;
       thunderboltKernelPatches = import ./kernel-workflow/patches;
-      systems = [
-        "x86_64-linux"
-      ];
+      linuxSystems = [ "x86_64-linux" ];
+      darwinSystems = [ "aarch64-darwin" ];
+      systems = linuxSystems ++ darwinSystems;
       forAllSystems = f:
         lib.genAttrs systems (system:
+          f (import nixpkgs { inherit system; }));
+      forLinuxSystems = f:
+        lib.genAttrs linuxSystems (system:
+          f (import nixpkgs { inherit system; }));
+      forDarwinSystems = f:
+        lib.genAttrs darwinSystems (system:
           f (import nixpkgs { inherit system; }));
       linuxSrcMakefile = builtins.readFile "${linux-src}/Makefile";
       linuxSrcMakeVars =
@@ -180,80 +186,91 @@
     {
       packages = forAllSystems (pkgs:
         let
-          module = pkgs.linuxPackages.callPackage ./nix/module.nix { };
-          thunderboltKernel = mkThunderboltKernel pkgs;
-          thunderboltLinuxPackages = mkThunderboltLinuxPackages pkgs;
-          moduleForThunderboltKernel =
-            thunderboltLinuxPackages.callPackage ./nix/module.nix { };
-          rdmaCoreUsb4 = mkRdmaCoreUsb4 pkgs;
-          perftest = pkgs.callPackage ./nix/perftest.nix {
-            rdma-core-usb4 = rdmaCoreUsb4;
-          };
-          benchTools = pkgs.callPackage ./nix/bench-tools.nix {
-            rdma-core-usb4 = rdmaCoreUsb4;
-          };
+          isLinux = pkgs.stdenv.hostPlatform.isLinux;
+          perftest = pkgs.callPackage ./nix/perftest.nix (
+            lib.optionalAttrs isLinux { rdma-core-usb4 = mkRdmaCoreUsb4 pkgs; }
+          );
+          benchTools = pkgs.callPackage ./nix/bench-tools.nix (
+            lib.optionalAttrs isLinux { rdma-core-usb4 = mkRdmaCoreUsb4 pkgs; }
+          );
         in
         {
-          default = module;
-          linux-thunderbolt = thunderboltKernel;
-          linux-thunderbolt-dev = thunderboltKernel.dev;
-          linux-thunderbolt-modules = thunderboltKernel.modules;
-          rdma-core-usb4 = rdmaCoreUsb4;
           perftest = perftest;
           bench-tools = benchTools;
-          thunderbolt-ibverbs = module;
-          thunderbolt-ibverbs-linux-thunderbolt = moduleForThunderboltKernel;
+        } // lib.optionalAttrs isLinux (
+          let
+            module = pkgs.linuxPackages.callPackage ./nix/module.nix { };
+            thunderboltKernel = mkThunderboltKernel pkgs;
+            thunderboltLinuxPackages = mkThunderboltLinuxPackages pkgs;
+            moduleForThunderboltKernel =
+              thunderboltLinuxPackages.callPackage ./nix/module.nix { };
+          in
+          {
+            default = module;
+            linux-thunderbolt = thunderboltKernel;
+            linux-thunderbolt-dev = thunderboltKernel.dev;
+            linux-thunderbolt-modules = thunderboltKernel.modules;
+            rdma-core-usb4 = mkRdmaCoreUsb4 pkgs;
+            thunderbolt-ibverbs = module;
+            thunderbolt-ibverbs-linux-thunderbolt = moduleForThunderboltKernel;
+          }
+        ));
+
+      checks = forAllSystems (pkgs:
+        let
+          isLinux = pkgs.stdenv.hostPlatform.isLinux;
+          pkgsAt = self.packages.${pkgs.stdenv.hostPlatform.system};
+        in
+        {
+          perftest = pkgsAt.perftest;
+          bench-tools = pkgsAt.bench-tools;
+        } // lib.optionalAttrs isLinux {
+          thunderbolt-ibverbs = pkgsAt.thunderbolt-ibverbs;
+          script-syntax = mkScriptSyntaxCheck pkgs;
+          proto-smoke = mkProtoSmoke pkgs;
+          rdma-core-usb4 = pkgsAt.rdma-core-usb4;
+          verbs-smoke-build = mkVerbsSmokeBuild pkgs;
         });
 
-      checks = forAllSystems (pkgs: {
-        thunderbolt-ibverbs =
-          self.packages.${pkgs.stdenv.hostPlatform.system}.thunderbolt-ibverbs;
-        script-syntax = mkScriptSyntaxCheck pkgs;
-        proto-smoke = mkProtoSmoke pkgs;
-        rdma-core-usb4 =
-          self.packages.${pkgs.stdenv.hostPlatform.system}.rdma-core-usb4;
-        verbs-smoke-build = mkVerbsSmokeBuild pkgs;
-      });
-
-      hydraJobs = forAllSystems (pkgs: {
-        thunderbolt-ibverbs =
-          self.packages.${pkgs.stdenv.hostPlatform.system}.thunderbolt-ibverbs;
-        linux-thunderbolt =
-          self.packages.${pkgs.stdenv.hostPlatform.system}.linux-thunderbolt;
-        linux-thunderbolt-dev =
-          self.packages.${pkgs.stdenv.hostPlatform.system}.linux-thunderbolt-dev;
-        linux-thunderbolt-modules =
-          self.packages.${pkgs.stdenv.hostPlatform.system}.linux-thunderbolt-modules;
-        rdma-core-usb4 =
-          self.packages.${pkgs.stdenv.hostPlatform.system}.rdma-core-usb4;
-        perftest =
-          self.packages.${pkgs.stdenv.hostPlatform.system}.perftest;
-        bench-tools =
-          self.packages.${pkgs.stdenv.hostPlatform.system}.bench-tools;
-        thunderbolt-ibverbs-linux-thunderbolt =
-          self.packages.${pkgs.stdenv.hostPlatform.system}.thunderbolt-ibverbs-linux-thunderbolt;
-        checks = self.checks.${pkgs.stdenv.hostPlatform.system};
-        vm-smoke.nixos = mkNixosVmSmoke pkgs;
-      });
+      hydraJobs = forAllSystems (pkgs:
+        let
+          isLinux = pkgs.stdenv.hostPlatform.isLinux;
+          pkgsAt = self.packages.${pkgs.stdenv.hostPlatform.system};
+        in
+        {
+          perftest = pkgsAt.perftest;
+          bench-tools = pkgsAt.bench-tools;
+          checks = self.checks.${pkgs.stdenv.hostPlatform.system};
+        } // lib.optionalAttrs isLinux {
+          thunderbolt-ibverbs = pkgsAt.thunderbolt-ibverbs;
+          linux-thunderbolt = pkgsAt.linux-thunderbolt;
+          linux-thunderbolt-dev = pkgsAt.linux-thunderbolt-dev;
+          linux-thunderbolt-modules = pkgsAt.linux-thunderbolt-modules;
+          rdma-core-usb4 = pkgsAt.rdma-core-usb4;
+          thunderbolt-ibverbs-linux-thunderbolt = pkgsAt.thunderbolt-ibverbs-linux-thunderbolt;
+          vm-smoke.nixos = mkNixosVmSmoke pkgs;
+        });
 
       devShells = forAllSystems (pkgs:
         let
+          isLinux = pkgs.stdenv.hostPlatform.isLinux;
           pkgsAt = self.packages.${pkgs.stdenv.hostPlatform.system};
         in
         {
           default = pkgs.mkShell {
             name = "thunderbolt-ibverbs-dev";
             packages = [
-              pkgs.kmod
               pkgs.python3
-              pkgsAt.rdma-core-usb4
               pkgsAt.perftest
               pkgsAt.bench-tools
+            ] ++ lib.optionals isLinux [
+              pkgs.kmod
+              pkgsAt.rdma-core-usb4
             ];
           };
         });
 
-      overlays.default = final: prev: {
+      overlays.default = final: prev: lib.optionalAttrs prev.stdenv.hostPlatform.isLinux {
         rdma-core-usb4 = mkRdmaCoreUsb4 final;
         thunderbolt-ibverbs =
           final.linuxPackages.callPackage ./nix/module.nix { };
@@ -261,7 +278,7 @@
 
       lib.kernelPatches = thunderboltKernelPatches;
 
-      legacyPackages = forAllSystems (_pkgs: {
+      legacyPackages = forLinuxSystems (_pkgs: {
         kernelPatches = thunderboltKernelPatches;
       });
 

--- a/nix/apple-compat/apple_raw_ethernet_stubs.c
+++ b/nix/apple-compat/apple_raw_ethernet_stubs.c
@@ -1,0 +1,42 @@
+#include <stdint.h>
+
+/*
+ * Raw Ethernet mode is disabled in the Darwin perftest build. These helpers
+ * are still referenced by common perftest objects, so keep dyld satisfied for
+ * the unreachable RawEth path without pretending to support flow steering.
+ */
+
+struct ibv_flow_attr;
+struct memory_ctx;
+struct perftest_parameters;
+struct pingpong_context;
+
+void print_ethernet_header(void *p_ethernet_header,
+			   struct perftest_parameters *user_param,
+			   struct memory_ctx *memory)
+{
+	(void)p_ethernet_header;
+	(void)user_param;
+	(void)memory;
+}
+
+void print_ethernet_vlan_header(void *p_ethernet_header,
+				struct perftest_parameters *user_param,
+				struct memory_ctx *memory)
+{
+	(void)p_ethernet_header;
+	(void)user_param;
+	(void)memory;
+}
+
+int set_up_fs_rules(struct ibv_flow_attr **flow_rules,
+		    struct pingpong_context *ctx,
+		    struct perftest_parameters *user_param,
+		    uint64_t allocated_flows)
+{
+	(void)flow_rules;
+	(void)ctx;
+	(void)user_param;
+	(void)allocated_flows;
+	return 1;
+}

--- a/nix/apple-compat/asm/byteorder.h
+++ b/nix/apple-compat/asm/byteorder.h
@@ -1,0 +1,19 @@
+#ifndef PERFTEST_APPLE_COMPAT_ASM_BYTEORDER_H
+#define PERFTEST_APPLE_COMPAT_ASM_BYTEORDER_H
+
+#include <stdint.h>
+
+#include "endian.h"
+
+typedef uint8_t __u8;
+typedef uint16_t __be16;
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+#define __LITTLE_ENDIAN_BITFIELD
+#elif BYTE_ORDER == BIG_ENDIAN
+#define __BIG_ENDIAN_BITFIELD
+#else
+#error "Must set BYTE_ORDER"
+#endif
+
+#endif

--- a/nix/apple-compat/byteswap.h
+++ b/nix/apple-compat/byteswap.h
@@ -1,0 +1,12 @@
+#ifndef PERFTEST_APPLE_COMPAT_BYTESWAP_H
+#define PERFTEST_APPLE_COMPAT_BYTESWAP_H
+
+#include <libkern/OSByteOrder.h>
+
+#include "endian.h"
+
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+
+#endif

--- a/nix/apple-compat/endian.h
+++ b/nix/apple-compat/endian.h
@@ -1,0 +1,34 @@
+#ifndef PERFTEST_APPLE_COMPAT_ENDIAN_H
+#define PERFTEST_APPLE_COMPAT_ENDIAN_H
+
+#include <libkern/OSByteOrder.h>
+#include <machine/endian.h>
+
+#ifndef BYTE_ORDER
+#define BYTE_ORDER __DARWIN_BYTE_ORDER
+#endif
+#ifndef LITTLE_ENDIAN
+#define LITTLE_ENDIAN __DARWIN_LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define BIG_ENDIAN __DARWIN_BIG_ENDIAN
+#endif
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#ifndef s6_addr32
+#define s6_addr32 __u6_addr.__u6_addr32
+#endif
+
+#endif

--- a/nix/apple-compat/infiniband/umad.h
+++ b/nix/apple-compat/infiniband/umad.h
@@ -1,0 +1,103 @@
+#ifndef PERFTEST_APPLE_COMPAT_INFINIBAND_UMAD_H
+#define PERFTEST_APPLE_COMPAT_INFINIBAND_UMAD_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+static inline int umad_init(void)
+{
+	return -1;
+}
+
+static inline int umad_open_port(char *ca_name, int portnum)
+{
+	(void)ca_name;
+	(void)portnum;
+	return -1;
+}
+
+static inline int umad_register(int portid, int mgmt_class, int mgmt_version,
+				uint32_t rmpp_version, long method_mask)
+{
+	(void)portid;
+	(void)mgmt_class;
+	(void)mgmt_version;
+	(void)rmpp_version;
+	(void)method_mask;
+	return -1;
+}
+
+static inline void *umad_alloc(int num, size_t size)
+{
+	return calloc((size_t)num, size);
+}
+
+static inline int umad_size(void)
+{
+	return 0;
+}
+
+static inline void *umad_get_mad(void *umad)
+{
+	return umad;
+}
+
+static inline void umad_set_pkey(void *umad, int pkey_index)
+{
+	(void)umad;
+	(void)pkey_index;
+}
+
+static inline int umad_set_addr(void *umad, int lid, int qpn, int sl,
+				uint32_t qkey)
+{
+	(void)umad;
+	(void)lid;
+	(void)qpn;
+	(void)sl;
+	(void)qkey;
+	return -1;
+}
+
+static inline int umad_send(int portid, int agentid, void *umad, int length,
+			    int timeout_ms, int retries)
+{
+	(void)portid;
+	(void)agentid;
+	(void)umad;
+	(void)length;
+	(void)timeout_ms;
+	(void)retries;
+	return -1;
+}
+
+static inline int umad_recv(int portid, void *umad, int *length,
+			    int timeout_ms)
+{
+	(void)portid;
+	(void)umad;
+	(void)length;
+	(void)timeout_ms;
+	return -1;
+}
+
+static inline void umad_free(void *umad)
+{
+	free(umad);
+}
+
+static inline int umad_unregister(int portid, int agentid)
+{
+	(void)portid;
+	(void)agentid;
+	return 0;
+}
+
+static inline int umad_close_port(int portid)
+{
+	(void)portid;
+	return 0;
+}
+
+#endif

--- a/nix/apple-compat/infiniband/verbs.h
+++ b/nix/apple-compat/infiniband/verbs.h
@@ -1,0 +1,89 @@
+#ifndef PERFTEST_APPLE_COMPAT_INFINIBAND_VERBS_H
+#define PERFTEST_APPLE_COMPAT_INFINIBAND_VERBS_H
+
+#include_next <infiniband/verbs.h>
+
+#ifndef __always_inline
+#define __always_inline __attribute__((__always_inline__)) inline
+#endif
+
+#ifndef IBV_ODP_SUPPORT_SEND
+#define IBV_ODP_SUPPORT_SEND (1 << 2)
+#endif
+#ifndef IBV_ODP_SUPPORT_RECV
+#define IBV_ODP_SUPPORT_RECV (1 << 3)
+#endif
+#ifndef IBV_ODP_SUPPORT_WRITE
+#define IBV_ODP_SUPPORT_WRITE (1 << 4)
+#endif
+#ifndef IBV_ODP_SUPPORT_READ
+#define IBV_ODP_SUPPORT_READ (1 << 5)
+#endif
+#ifndef IBV_ODP_SUPPORT_ATOMIC
+#define IBV_ODP_SUPPORT_ATOMIC (1 << 6)
+#endif
+#ifndef IBV_ODP_SUPPORT_SRQ_RECV
+#define IBV_ODP_SUPPORT_SRQ_RECV (1 << 7)
+#endif
+
+struct ibv_srq_attr {
+	uint32_t max_wr;
+	uint32_t max_sge;
+	uint32_t srq_limit;
+};
+
+struct ibv_srq_init_attr {
+	void *srq_context;
+	struct ibv_srq_attr attr;
+};
+
+enum ibv_srq_type {
+	IBV_SRQT_BASIC,
+	IBV_SRQT_XRC,
+};
+
+struct ibv_srq_init_attr_ex {
+	void *srq_context;
+	struct ibv_srq_attr attr;
+	uint32_t comp_mask;
+	enum ibv_srq_type srq_type;
+	struct ibv_pd *pd;
+	struct ibv_cq *cq;
+	struct ibv_xrcd *xrcd;
+};
+
+#ifndef IBV_SRQ_INIT_ATTR_TYPE
+#define IBV_SRQ_INIT_ATTR_TYPE (1 << 0)
+#endif
+#ifndef IBV_SRQ_INIT_ATTR_PD
+#define IBV_SRQ_INIT_ATTR_PD (1 << 1)
+#endif
+#ifndef IBV_SRQ_INIT_ATTR_CQ
+#define IBV_SRQ_INIT_ATTR_CQ (1 << 2)
+#endif
+#ifndef IBV_SRQ_INIT_ATTR_XRCD
+#define IBV_SRQ_INIT_ATTR_XRCD (1 << 3)
+#endif
+
+struct ibv_flow;
+struct ibv_flow_attr;
+
+#ifndef HAVE_EX_ODP
+#define check_odp_support(ctx, user_param) 0
+#endif
+
+int ibv_get_srq_num(struct ibv_srq *srq, uint32_t *srq_num);
+int ibv_attach_mcast(struct ibv_qp *qp, const union ibv_gid *gid, uint16_t lid);
+int ibv_detach_mcast(struct ibv_qp *qp, const union ibv_gid *gid, uint16_t lid);
+struct ibv_srq *ibv_create_srq(struct ibv_pd *pd, struct ibv_srq_init_attr *srq_init_attr);
+struct ibv_srq *ibv_create_srq_ex(struct ibv_context *context,
+				  struct ibv_srq_init_attr_ex *srq_init_attr_ex);
+int ibv_destroy_srq(struct ibv_srq *srq);
+int ibv_post_srq_recv(struct ibv_srq *srq, struct ibv_recv_wr *recv_wr,
+		      struct ibv_recv_wr **bad_recv_wr);
+struct ibv_mr *ibv_alloc_null_mr(struct ibv_pd *pd);
+struct ibv_flow *ibv_create_flow(struct ibv_qp *qp,
+				 struct ibv_flow_attr *flow_attr);
+int ibv_destroy_flow(struct ibv_flow *flow);
+
+#endif

--- a/nix/apple-compat/malloc.h
+++ b/nix/apple-compat/malloc.h
@@ -1,0 +1,29 @@
+#ifndef PERFTEST_APPLE_COMPAT_MALLOC_H
+#define PERFTEST_APPLE_COMPAT_MALLOC_H
+
+#include <alloca.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef SHM_HUGETLB
+#define SHM_HUGETLB 0
+#endif
+#ifndef _SC_LEVEL1_DCACHE_LINESIZE
+#define _SC_LEVEL1_DCACHE_LINESIZE (-1)
+#endif
+
+static inline void *memalign(size_t alignment, size_t size)
+{
+	void *ptr = NULL;
+
+	if (posix_memalign(&ptr, alignment, size) != 0)
+		return NULL;
+
+	return ptr;
+}
+
+#ifndef strdupa
+#define strdupa(s) strcpy((char *)alloca(strlen(s) + 1), (s))
+#endif
+
+#endif

--- a/nix/apple-compat/rdma/rdma_cma.h
+++ b/nix/apple-compat/rdma/rdma_cma.h
@@ -1,0 +1,203 @@
+#ifndef PERFTEST_APPLE_COMPAT_RDMA_CMA_H
+#define PERFTEST_APPLE_COMPAT_RDMA_CMA_H
+
+#include <netinet/in.h>
+#include <stdint.h>
+#include <sys/socket.h>
+
+#include <infiniband/verbs.h>
+
+typedef uint16_t __be16;
+
+struct ibv_sa_path_rec;
+
+enum rdma_cm_event_type {
+	RDMA_CM_EVENT_ADDR_RESOLVED,
+	RDMA_CM_EVENT_ADDR_ERROR,
+	RDMA_CM_EVENT_ROUTE_RESOLVED,
+	RDMA_CM_EVENT_ROUTE_ERROR,
+	RDMA_CM_EVENT_CONNECT_REQUEST,
+	RDMA_CM_EVENT_CONNECT_RESPONSE,
+	RDMA_CM_EVENT_CONNECT_ERROR,
+	RDMA_CM_EVENT_UNREACHABLE,
+	RDMA_CM_EVENT_REJECTED,
+	RDMA_CM_EVENT_ESTABLISHED,
+	RDMA_CM_EVENT_DISCONNECTED,
+	RDMA_CM_EVENT_DEVICE_REMOVAL,
+	RDMA_CM_EVENT_MULTICAST_JOIN,
+	RDMA_CM_EVENT_MULTICAST_ERROR,
+	RDMA_CM_EVENT_ADDR_CHANGE,
+	RDMA_CM_EVENT_TIMEWAIT_EXIT,
+	RDMA_CM_EVENT_ADDRINFO_RESOLVED,
+	RDMA_CM_EVENT_ADDRINFO_ERROR,
+	RDMA_CM_EVENT_USER,
+	RDMA_CM_EVENT_INTERNAL,
+};
+
+enum rdma_port_space {
+	RDMA_PS_IPOIB = 0x0002,
+	RDMA_PS_TCP = 0x0106,
+	RDMA_PS_UDP = 0x0111,
+	RDMA_PS_IB = 0x013F,
+};
+
+struct rdma_ib_addr {
+	union ibv_gid sgid;
+	union ibv_gid dgid;
+	__be16 pkey;
+};
+
+struct rdma_addr {
+	union {
+		struct sockaddr src_addr;
+		struct sockaddr_in src_sin;
+		struct sockaddr_in6 src_sin6;
+		struct sockaddr_storage src_storage;
+	};
+	union {
+		struct sockaddr dst_addr;
+		struct sockaddr_in dst_sin;
+		struct sockaddr_in6 dst_sin6;
+		struct sockaddr_storage dst_storage;
+	};
+	union {
+		struct rdma_ib_addr ibaddr;
+	} addr;
+};
+
+struct rdma_route {
+	struct rdma_addr addr;
+	struct ibv_sa_path_rec *path_rec;
+	int num_paths;
+};
+
+struct rdma_event_channel {
+	int fd;
+};
+
+struct rdma_cm_id {
+	struct ibv_context *verbs;
+	struct rdma_event_channel *channel;
+	void *context;
+	struct ibv_qp *qp;
+	struct rdma_route route;
+	enum rdma_port_space ps;
+	uint8_t port_num;
+	struct rdma_cm_event *event;
+	struct ibv_comp_channel *send_cq_channel;
+	struct ibv_cq *send_cq;
+	struct ibv_comp_channel *recv_cq_channel;
+	struct ibv_cq *recv_cq;
+	struct ibv_srq *srq;
+	struct ibv_pd *pd;
+	enum ibv_qp_type qp_type;
+};
+
+struct rdma_conn_param {
+	const void *private_data;
+	uint8_t private_data_len;
+	uint8_t responder_resources;
+	uint8_t initiator_depth;
+	uint8_t flow_control;
+	uint8_t retry_count;
+	uint8_t rnr_retry_count;
+	uint8_t srq;
+	uint32_t qp_num;
+};
+
+struct rdma_ud_param {
+	const void *private_data;
+	uint8_t private_data_len;
+	struct ibv_ah_attr ah_attr;
+	uint32_t qp_num;
+	uint32_t qkey;
+};
+
+struct rdma_cm_event {
+	struct rdma_cm_id *id;
+	struct rdma_cm_id *listen_id;
+	enum rdma_cm_event_type event;
+	int status;
+	union {
+		struct rdma_conn_param conn;
+		struct rdma_ud_param ud;
+		uint64_t arg;
+	} param;
+};
+
+#define RAI_PASSIVE 0x00000001
+#define RAI_NUMERICHOST 0x00000002
+#define RAI_NOROUTE 0x00000004
+#define RAI_FAMILY 0x00000008
+
+struct rdma_addrinfo {
+	int ai_flags;
+	int ai_family;
+	int ai_qp_type;
+	int ai_port_space;
+	socklen_t ai_src_len;
+	socklen_t ai_dst_len;
+	struct sockaddr *ai_src_addr;
+	struct sockaddr *ai_dst_addr;
+	char *ai_src_canonname;
+	char *ai_dst_canonname;
+	size_t ai_route_len;
+	void *ai_route;
+	size_t ai_connect_len;
+	void *ai_connect;
+	struct rdma_addrinfo *ai_next;
+};
+
+enum {
+	RDMA_OPTION_ID = 0,
+	RDMA_OPTION_IB = 1,
+};
+
+enum {
+	RDMA_OPTION_ID_TOS = 0,
+	RDMA_OPTION_ID_REUSEADDR = 1,
+	RDMA_OPTION_ID_AFONLY = 2,
+	RDMA_OPTION_ID_ACK_TIMEOUT = 3,
+};
+
+struct rdma_event_channel *rdma_create_event_channel(void);
+void rdma_destroy_event_channel(struct rdma_event_channel *channel);
+int rdma_create_id(struct rdma_event_channel *channel,
+		   struct rdma_cm_id **id, void *context,
+		   enum rdma_port_space ps);
+int rdma_destroy_id(struct rdma_cm_id *id);
+int rdma_bind_addr(struct rdma_cm_id *id, struct sockaddr *addr);
+int rdma_resolve_addr(struct rdma_cm_id *id, struct sockaddr *src_addr,
+		      struct sockaddr *dst_addr, int timeout_ms);
+int rdma_resolve_route(struct rdma_cm_id *id, int timeout_ms);
+int rdma_create_qp(struct rdma_cm_id *id, struct ibv_pd *pd,
+		   struct ibv_qp_init_attr *qp_init_attr);
+void rdma_destroy_qp(struct rdma_cm_id *id);
+int rdma_connect(struct rdma_cm_id *id, struct rdma_conn_param *conn_param);
+int rdma_listen(struct rdma_cm_id *id, int backlog);
+int rdma_accept(struct rdma_cm_id *id, struct rdma_conn_param *conn_param);
+int rdma_reject(struct rdma_cm_id *id, const void *private_data,
+		uint8_t private_data_len);
+int rdma_disconnect(struct rdma_cm_id *id);
+int rdma_get_cm_event(struct rdma_event_channel *channel,
+		      struct rdma_cm_event **event);
+int rdma_ack_cm_event(struct rdma_cm_event *event);
+const char *rdma_event_str(enum rdma_cm_event_type event);
+int rdma_set_option(struct rdma_cm_id *id, int level, int optname,
+		    void *optval, size_t optlen);
+int rdma_getaddrinfo(const char *node, const char *service,
+		     const struct rdma_addrinfo *hints,
+		     struct rdma_addrinfo **res);
+void rdma_freeaddrinfo(struct rdma_addrinfo *res);
+
+static inline struct sockaddr *rdma_get_local_addr(struct rdma_cm_id *id)
+{
+	return &id->route.addr.src_addr;
+}
+
+static inline struct sockaddr *rdma_get_peer_addr(struct rdma_cm_id *id)
+{
+	return &id->route.addr.dst_addr;
+}
+
+#endif

--- a/nix/bench-tools.nix
+++ b/nix/bench-tools.nix
@@ -1,28 +1,43 @@
 { lib
 , stdenv
 , pkg-config
-, rdma-core-usb4
+, rdma-core-usb4 ? null
 , python3
 , source ? ../userspace/bench
+, appleCompat ? ./apple-compat
 }:
 
 let
-  # Standalone C programs. Each is built as $out/bin/<name> from <name>.c.
-  cPrograms = [
-    "mac_tb_rdma_probe"
+  isDarwin = stdenv.hostPlatform.isDarwin;
+
+  # Programs portable to Apple's RDMA host SDK (linked via dynamic_lookup):
+  # plain libibverbs verbs surface, no Linux-specific kernel uapi or
+  # LD_PRELOAD-style entrypoints.
+  darwinPrograms = [
     "rc_write_poll"
     "rc_write_verify"
     "u4_pingpong"
     "uc_oneway"
   ];
-  # ibv_trace.c is an LD_PRELOAD tracer; built as $out/lib/libibv_trace.so.
+
+  # Full Linux set. ibv_trace (LD_PRELOAD tracer, built as .so) and
+  # mac_tb_rdma_probe (Linux-side prober of Mac peers) are Linux-only.
+  linuxPrograms = darwinPrograms ++ [
+    "mac_tb_rdma_probe"
+  ];
+
   scripts = [
     "tbv_perftest_runner.py"
     "tbv_rdma_sweep.py"
   ];
+
+  cPrograms = if isDarwin then darwinPrograms else linuxPrograms;
 in
 stdenv.mkDerivation {
-  pname = "thunderbolt-ibverbs-bench-tools";
+  pname =
+    if isDarwin
+    then "thunderbolt-ibverbs-bench-tools-apple-rdma"
+    else "thunderbolt-ibverbs-bench-tools";
   version = "0.1.0";
 
   src = lib.cleanSourceWith {
@@ -36,42 +51,56 @@ stdenv.mkDerivation {
         || lib.hasSuffix ".sh" rel;
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ rdma-core-usb4 python3 ];
+  nativeBuildInputs = lib.optionals (!isDarwin) [ pkg-config ];
+  buildInputs = lib.optionals (!isDarwin) [ rdma-core-usb4 ] ++ [ python3 ];
 
   dontConfigure = true;
 
-  buildPhase = ''
-    runHook preBuild
-    for name in ${lib.concatStringsSep " " cPrograms}; do
-      extra=""
-      case "$name" in
-        uc_oneway) extra="-ldl" ;;
-      esac
-      $CC -O2 -Wall -Wextra -std=gnu11 \
+  buildPhase =
+    if isDarwin then ''
+      runHook preBuild
+      for name in ${lib.concatStringsSep " " cPrograms}; do
+        $CC -O2 -Wall -Wextra -std=gnu11 \
+          -I${appleCompat} \
+          "$name.c" \
+          -Wl,-undefined,dynamic_lookup \
+          -o "$name"
+      done
+      runHook postBuild
+    '' else ''
+      runHook preBuild
+      for name in ${lib.concatStringsSep " " cPrograms}; do
+        extra=""
+        case "$name" in
+          uc_oneway) extra="-ldl" ;;
+        esac
+        $CC -O2 -Wall -Wextra -std=gnu11 \
+          -I${rdma-core-usb4.dev}/include \
+          "$name.c" \
+          -L${rdma-core-usb4}/lib -libverbs \
+          $extra \
+          -Wl,-rpath,${rdma-core-usb4}/lib \
+          -o "$name"
+      done
+      $CC -O2 -Wall -Wextra -fPIC -shared \
         -I${rdma-core-usb4.dev}/include \
-        "$name.c" \
+        ibv_trace.c \
+        -ldl -lpthread \
         -L${rdma-core-usb4}/lib -libverbs \
-        $extra \
         -Wl,-rpath,${rdma-core-usb4}/lib \
-        -o "$name"
-    done
-    $CC -O2 -Wall -Wextra -fPIC -shared \
-      -I${rdma-core-usb4.dev}/include \
-      ibv_trace.c \
-      -ldl -lpthread \
-      -L${rdma-core-usb4}/lib -libverbs \
-      -Wl,-rpath,${rdma-core-usb4}/lib \
-      -o libibv_trace.so
-    runHook postBuild
-  '';
+        -o libibv_trace.so
+      runHook postBuild
+    '';
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin $out/lib
+    mkdir -p $out/bin
     install -m 0755 ${lib.concatStringsSep " " cPrograms} $out/bin/
     install -m 0755 ${lib.concatStringsSep " " scripts} $out/bin/
-    install -m 0644 libibv_trace.so $out/lib/
+    ${lib.optionalString (!isDarwin) ''
+      mkdir -p $out/lib
+      install -m 0644 libibv_trace.so $out/lib/
+    ''}
     runHook postInstall
   '';
 
@@ -80,8 +109,8 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "Thunderbolt/USB4 RDMA bench programs (libibverbs C tools + perftest/vllm helper scripts)";
+    description = "Thunderbolt/USB4 RDMA bench programs (libibverbs C tools + perftest helper scripts)";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = if isDarwin then platforms.darwin else platforms.linux;
   };
 }

--- a/nix/perftest.nix
+++ b/nix/perftest.nix
@@ -3,8 +3,9 @@
 , fetchFromGitHub
 , autoreconfHook
 , pkg-config
-, rdma-core-usb4
-, pciutils
+, rdma-core-usb4 ? null
+, pciutils ? null
+, appleCompat ? ./apple-compat
 }:
 
 let
@@ -15,24 +16,78 @@ let
     hash = "sha256-WcFOaG5Lzn87EZCZ8w6UTI6qtfX1wOtvF/lxSDwjEq4=";
   };
 in
-stdenv.mkDerivation {
-  pname = "perftest";
-  version = "26.01.5";
-  src = perftest-src;
+if stdenv.hostPlatform.isDarwin then
+  # Build perftest on Apple Macs using nixpkgs' Darwin stdenv (no Xcode
+  # hardcoded paths, no __noChroot). Headers come from the apple-compat shim
+  # that provides Linux-style <infiniband/verbs.h>, <rdma/rdma_cma.h>, etc.;
+  # the linker is told to defer libibverbs symbol resolution to dyld via
+  # -undefined dynamic_lookup. Apple's RDMA stack provides those symbols at
+  # runtime on Macs with USB4-RDMA-capable hardware.
+  stdenv.mkDerivation {
+    pname = "perftest-apple-rdma";
+    version = "26.01.5";
+    src = perftest-src;
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ rdma-core-usb4 pciutils ];
+    nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags = [
-    "--disable-cuda"
-    "--disable-rocm"
-    "--disable-neuron"
-  ];
+    postPatch = ''
+      cp -r ${appleCompat} apple-compat
+      chmod -R u+w apple-compat
+      cp apple-compat/apple_raw_ethernet_stubs.c src/apple_raw_ethernet_stubs.c
 
-  meta = with lib; {
-    description = "Open Fabrics Enterprise Distribution InfiniBand performance tests (linked against rdma-core-usb4)";
-    homepage = "https://github.com/linux-rdma/perftest";
-    license = licenses.bsd2;
-    platforms = platforms.linux;
-  };
-}
+      substituteInPlace configure.ac \
+        --replace-fail 'AC_CHECK_LIB([ibverbs], [ibv_get_device_list], [], [AC_MSG_ERROR([libibverbs not found])])' 'AC_MSG_NOTICE([using Apple RDMA verbs via dynamic lookup])' \
+        --replace-fail 'AC_CHECK_LIB([rdmacm], [rdma_create_event_channel], [], AC_MSG_ERROR([librdmacm-devel not found]))' 'AC_MSG_NOTICE([librdmacm unavailable on Darwin; rdma_cm mode is not supported])' \
+        --replace-fail 'AC_CHECK_LIB([ibumad], [umad_init], [LIBUMAD=-libumad], AC_MSG_ERROR([libibumad not found]))' 'LIBUMAD=' \
+        --replace-fail 'AC_CHECK_LIB([ibverbs], [ibv_reg_dmabuf_mr], [HAVE_REG_DMABUF_MR=yes], [HAVE_REG_DMABUF_MR=no])' 'HAVE_REG_DMABUF_MR=no' \
+        --replace-fail '[struct ibv_flow *t = ibv_create_flow(NULL,NULL);],[HAVE_RAW_ETH_REG=yes], [HAVE_RAW_ETH_REG=no])' '[struct ibv_flow *t = NULL;],[HAVE_RAW_ETH_REG=no], [HAVE_RAW_ETH_REG=no])' \
+        --replace-fail '[int x = IBV_ACCESS_ON_DEMAND;],[HAVE_EX_ODP=yes], [HAVE_EX_ODP=no])' '[int x = IBV_ACCESS_ON_DEMAND;],[HAVE_EX_ODP=no], [HAVE_EX_ODP=no])' \
+        --replace-fail 'if [test $IS_FREEBSD = no]; then' 'if false; then' \
+        --replace-fail 'AC_CHECK_LIB([dl], [dlclose],' 'AC_CHECK_LIB([System], [printf],' \
+        --replace-fail '     LIBS="$LIBS -ldl"],' '     LIBS="$LIBS"],'
+      substituteInPlace src/perftest_resources.c \
+        --replace-fail 'goto xrc_srq;' 'goto xrcd;'
+      substituteInPlace Makefile.am \
+        --replace-fail 'src/host_memory.c src/mmap_memory.c' 'src/host_memory.c src/mmap_memory.c src/apple_raw_ethernet_stubs.c'
+    '';
+
+    env.NIX_CFLAGS_COMPILE = "-I./apple-compat";
+    env.NIX_LDFLAGS = "-Wl,-undefined,dynamic_lookup";
+
+    configureFlags = [
+      "--disable-cuda"
+      "--disable-rocm"
+      "--disable-neuron"
+      "--disable-ibv_wr_api"
+    ];
+
+    meta = with lib; {
+      description = "OFED InfiniBand performance tests (Apple RDMA host SDK build, deferred symbol resolution)";
+      homepage = "https://github.com/linux-rdma/perftest";
+      license = licenses.bsd2;
+      platforms = platforms.darwin;
+    };
+  }
+else
+  # Linux build against our rdma-core-usb4 provider.
+  stdenv.mkDerivation {
+    pname = "perftest";
+    version = "26.01.5";
+    src = perftest-src;
+
+    nativeBuildInputs = [ autoreconfHook pkg-config ];
+    buildInputs = [ rdma-core-usb4 pciutils ];
+
+    configureFlags = [
+      "--disable-cuda"
+      "--disable-rocm"
+      "--disable-neuron"
+    ];
+
+    meta = with lib; {
+      description = "OFED InfiniBand performance tests (linked against rdma-core-usb4)";
+      homepage = "https://github.com/linux-rdma/perftest";
+      license = licenses.bsd2;
+      platforms = platforms.linux;
+    };
+  }


### PR DESCRIPTION
## Summary

Adds Apple Mac userspace builds of perftest and a subset of the bench probes (`uc_oneway`, `rc_write_poll`, `rc_write_verify`, `u4_pingpong`) without the Xcode-rooted `__noChroot` dance the parent repo's heavy perftest derivation used.

**Approach**: use nixpkgs' Darwin stdenv normally (sandboxed, default SDK), include our `apple-compat/` shim headers so `configure.ac` and the libibverbs surface compile, and pass `-Wl,-undefined,dynamic_lookup` so Apple's RDMA host SDK symbols resolve at runtime on the target Mac. Apple's RDMA stack is a private system framework that doesn't have to be present (or even installed) at build time.

The parent's Xcode-path dance was needed for ds4's `.metal` compiler (only ships in Xcode); perftest is plain C and doesn't need any of that.

## Layout

- `nix/apple-compat/` — header shim (`infiniband/verbs.h`, `rdma/rdma_cma.h`, etc.) + `apple_raw_ethernet_stubs.c`
- `nix/perftest.nix` — branches on `stdenv.hostPlatform.isDarwin`: Linux unchanged; Darwin gets `configure.ac` substitutions, the shim include path, and `dynamic_lookup` LDFLAGS
- `nix/bench-tools.nix` — branches similarly; Darwin builds 4 portable probes
- `flake.nix` — adds `aarch64-darwin` to systems, splits package/check/hydra outputs by platform via `lib.optionalAttrs` and a new `forLinuxSystems` helper

## Test plan

- [x] `nix flake check --no-build --all-systems` passes for both `x86_64-linux` and `aarch64-darwin`
- [x] Linux build of `perftest` + `bench-tools` rebuilt locally to confirm the refactor didn't regress
- [ ] Darwin build verified by Hydra on the aarch64-darwin (apple-m4) builder declared in `infra/network.nix`

`ibv_trace.c` (LD_PRELOAD tracer) and `mac_tb_rdma_probe.c` (Linux-side prober of Mac peers) stay Linux-only.