### PR TITLE
nix: expose thunderbolt package overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ On NixOS, add the flake input and import the module:
 }
 ```
 
+Downstream flakes can compose the package set through the default overlay:
+
+```nix
+{
+  nixpkgs.overlays = [
+    thunderbolt-ibverbs.overlays.default
+  ];
+}
+```
+
+The overlay provides `rdma-core-usb4`, `thunderbolt-ibverbs`,
+`thunderbolt-ibverbs-perftest`, and `thunderbolt-ibverbs-bench-tools` on Linux.
+
 ## Load And Use
 
 Connect the Thunderbolt/USB4 hosts first. On both Linux peers, load the module

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
           pname = "rdma-core-usb4";
           patches = (old.patches or [ ]) ++ rdmaCoreUsb4Patches;
         });
+      mkAppleRdmaSdk = pkgs: pkgs.callPackage ./nix/apple-rdma-sdk.nix { };
       mkScriptSyntaxCheck =
         pkgs:
         pkgs.stdenv.mkDerivation {
@@ -193,16 +194,20 @@
         pkgs:
         let
           isLinux = pkgs.stdenv.hostPlatform.isLinux;
-          perftest = pkgs.callPackage ./nix/perftest.nix (
+          isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+          appleRdmaSdk = mkAppleRdmaSdk pkgs;
+          packageArgs =
             lib.optionalAttrs isLinux { rdma-core-usb4 = mkRdmaCoreUsb4 pkgs; }
-          );
-          benchTools = pkgs.callPackage ./nix/bench-tools.nix (
-            lib.optionalAttrs isLinux { rdma-core-usb4 = mkRdmaCoreUsb4 pkgs; }
-          );
+            // lib.optionalAttrs isDarwin { inherit appleRdmaSdk; };
+          perftest = pkgs.callPackage ./nix/perftest.nix packageArgs;
+          benchTools = pkgs.callPackage ./nix/bench-tools.nix packageArgs;
         in
         {
           perftest = perftest;
           bench-tools = benchTools;
+        }
+        // lib.optionalAttrs isDarwin {
+          apple-rdma-sdk = appleRdmaSdk;
         }
         // lib.optionalAttrs isLinux (
           let
@@ -290,13 +295,20 @@
         final: prev:
         let
           isLinux = prev.stdenv.hostPlatform.isLinux;
-          rdmaCoreArgs = lib.optionalAttrs isLinux {
+          isDarwin = prev.stdenv.hostPlatform.isDarwin;
+          packageArgs = lib.optionalAttrs isLinux {
             rdma-core-usb4 = final.rdma-core-usb4;
+          } // lib.optionalAttrs isDarwin {
+            appleRdmaSdk = final.apple-rdma-sdk;
           };
         in
         {
-          thunderbolt-ibverbs-bench-tools = final.callPackage ./nix/bench-tools.nix rdmaCoreArgs;
-          thunderbolt-ibverbs-perftest = final.callPackage ./nix/perftest.nix rdmaCoreArgs;
+          thunderbolt-ibverbs-bench-tools = final.callPackage ./nix/bench-tools.nix packageArgs;
+          thunderbolt-ibverbs-perftest = final.callPackage ./nix/perftest.nix packageArgs;
+        }
+        // lib.optionalAttrs isDarwin {
+          apple-rdma-sdk = final.callPackage ./nix/apple-rdma-sdk.nix { };
+          thunderbolt-ibverbs-apple-rdma-sdk = final.apple-rdma-sdk;
         }
         // lib.optionalAttrs isLinux (
           let

--- a/flake.nix
+++ b/flake.nix
@@ -10,30 +10,31 @@
     };
   };
 
-  outputs = { self, nixpkgs, linux-src }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      linux-src,
+    }:
     let
       lib = nixpkgs.lib;
       thunderboltKernelPatches = import ./kernel-workflow/patches;
       linuxSystems = [ "x86_64-linux" ];
       darwinSystems = [ "aarch64-darwin" ];
       systems = linuxSystems ++ darwinSystems;
-      forAllSystems = f:
-        lib.genAttrs systems (system:
-          f (import nixpkgs { inherit system; }));
-      forLinuxSystems = f:
-        lib.genAttrs linuxSystems (system:
-          f (import nixpkgs { inherit system; }));
-      forDarwinSystems = f:
-        lib.genAttrs darwinSystems (system:
-          f (import nixpkgs { inherit system; }));
+      forAllSystems = f: lib.genAttrs systems (system: f (import nixpkgs { inherit system; }));
+      forLinuxSystems = f: lib.genAttrs linuxSystems (system: f (import nixpkgs { inherit system; }));
+      forDarwinSystems = f: lib.genAttrs darwinSystems (system: f (import nixpkgs { inherit system; }));
       linuxSrcMakefile = builtins.readFile "${linux-src}/Makefile";
       linuxSrcMakeVars =
         let
           lines = lib.splitString "\n" linuxSrcMakefile;
-          readVar = name:
+          readVar =
+            name:
             let
-              matches = lib.filter (match: match != null)
-                (map (line: builtins.match "${name}[[:space:]]*=[[:space:]]*(.*)" line) lines);
+              matches = lib.filter (match: match != null) (
+                map (line: builtins.match "${name}[[:space:]]*=[[:space:]]*(.*)" line) lines
+              );
             in
             if matches == [ ] then
               throw "could not read ${name} from Linux Makefile"
@@ -46,14 +47,12 @@
           sublevel = readVar "SUBLEVEL";
           extraversion = readVar "EXTRAVERSION";
         };
-      linuxSrcVersion =
-        "${linuxSrcMakeVars.version}.${linuxSrcMakeVars.patchlevel}.${linuxSrcMakeVars.sublevel}${linuxSrcMakeVars.extraversion}";
-      mkThunderboltKernel = pkgs:
+      linuxSrcVersion = "${linuxSrcMakeVars.version}.${linuxSrcMakeVars.patchlevel}.${linuxSrcMakeVars.sublevel}${linuxSrcMakeVars.extraversion}";
+      mkThunderboltKernel =
+        pkgs:
         let
           testingKernel = pkgs.linuxPackages_testing.kernel;
-          kernelPatches =
-            (testingKernel.passthru.kernelPatches or [ ])
-            ++ thunderboltKernelPatches;
+          kernelPatches = (testingKernel.passthru.kernelPatches or [ ]) ++ thunderboltKernelPatches;
         in
         testingKernel.override {
           argsOverride = {
@@ -64,19 +63,20 @@
             inherit kernelPatches;
           };
         };
-      mkThunderboltLinuxPackages = pkgs:
-        pkgs.linuxPackagesFor (mkThunderboltKernel pkgs);
+      mkThunderboltLinuxPackages = pkgs: pkgs.linuxPackagesFor (mkThunderboltKernel pkgs);
       rdmaCoreUsb4Patches = [
         ./packaging/rdma-core-patches/0001-providers-usb4_rdma-add-USB4-soft-RDMA-provider.patch
         ./packaging/rdma-core-patches/0002-CMakeLists.txt-build-the-usb4_rdma-provider.patch
         ./packaging/rdma-core-patches/0003-libibverbs-verbs.h-declare-verbs_provider_usb4_rdma.patch
       ];
-      mkRdmaCoreUsb4 = pkgs:
+      mkRdmaCoreUsb4 =
+        pkgs:
         pkgs.rdma-core.overrideAttrs (old: {
           pname = "rdma-core-usb4";
           patches = (old.patches or [ ]) ++ rdmaCoreUsb4Patches;
         });
-      mkScriptSyntaxCheck = pkgs:
+      mkScriptSyntaxCheck =
+        pkgs:
         pkgs.stdenv.mkDerivation {
           pname = "thunderbolt-ibverbs-script-syntax";
           version = "0.1.0";
@@ -106,7 +106,8 @@
             runHook postInstall
           '';
         };
-      mkProtoSmoke = pkgs:
+      mkProtoSmoke =
+        pkgs:
         pkgs.stdenv.mkDerivation {
           pname = "thunderbolt-ibverbs-proto-smoke";
           version = "0.1.0";
@@ -129,7 +130,8 @@
             runHook postInstall
           '';
         };
-      mkNixosVmSmoke = pkgs:
+      mkNixosVmSmoke =
+        pkgs:
         let
           module = pkgs.linuxPackages.callPackage ./nix/module.nix { };
           rdmaCoreUsb4 = mkRdmaCoreUsb4 pkgs;
@@ -137,13 +139,15 @@
         pkgs.testers.runNixOSTest {
           name = "thunderbolt-ibverbs-vm-smoke";
 
-          nodes.machine = { pkgs, ... }: {
-            boot.extraModulePackages = [ module ];
-            environment.systemPackages = [
-              pkgs.kmod
-              rdmaCoreUsb4
-            ];
-          };
+          nodes.machine =
+            { pkgs, ... }:
+            {
+              boot.extraModulePackages = [ module ];
+              environment.systemPackages = [
+                pkgs.kmod
+                rdmaCoreUsb4
+              ];
+            };
 
           testScript = ''
             machine.start()
@@ -156,7 +160,8 @@
             machine.succeed("rmmod thunderbolt_ibverbs")
           '';
         };
-      mkVerbsSmokeBuild = pkgs:
+      mkVerbsSmokeBuild =
+        pkgs:
         pkgs.stdenv.mkDerivation {
           pname = "thunderbolt-ibverbs-verbs-smoke-build";
           version = "0.1.0";
@@ -184,7 +189,8 @@
         };
     in
     {
-      packages = forAllSystems (pkgs:
+      packages = forAllSystems (
+        pkgs:
         let
           isLinux = pkgs.stdenv.hostPlatform.isLinux;
           perftest = pkgs.callPackage ./nix/perftest.nix (
@@ -197,13 +203,13 @@
         {
           perftest = perftest;
           bench-tools = benchTools;
-        } // lib.optionalAttrs isLinux (
+        }
+        // lib.optionalAttrs isLinux (
           let
             module = pkgs.linuxPackages.callPackage ./nix/module.nix { };
             thunderboltKernel = mkThunderboltKernel pkgs;
             thunderboltLinuxPackages = mkThunderboltLinuxPackages pkgs;
-            moduleForThunderboltKernel =
-              thunderboltLinuxPackages.callPackage ./nix/module.nix { };
+            moduleForThunderboltKernel = thunderboltLinuxPackages.callPackage ./nix/module.nix { };
           in
           {
             default = module;
@@ -214,9 +220,11 @@
             thunderbolt-ibverbs = module;
             thunderbolt-ibverbs-linux-thunderbolt = moduleForThunderboltKernel;
           }
-        ));
+        )
+      );
 
-      checks = forAllSystems (pkgs:
+      checks = forAllSystems (
+        pkgs:
         let
           isLinux = pkgs.stdenv.hostPlatform.isLinux;
           pkgsAt = self.packages.${pkgs.stdenv.hostPlatform.system};
@@ -224,15 +232,18 @@
         {
           perftest = pkgsAt.perftest;
           bench-tools = pkgsAt.bench-tools;
-        } // lib.optionalAttrs isLinux {
+        }
+        // lib.optionalAttrs isLinux {
           thunderbolt-ibverbs = pkgsAt.thunderbolt-ibverbs;
           script-syntax = mkScriptSyntaxCheck pkgs;
           proto-smoke = mkProtoSmoke pkgs;
           rdma-core-usb4 = pkgsAt.rdma-core-usb4;
           verbs-smoke-build = mkVerbsSmokeBuild pkgs;
-        });
+        }
+      );
 
-      hydraJobs = forAllSystems (pkgs:
+      hydraJobs = forAllSystems (
+        pkgs:
         let
           isLinux = pkgs.stdenv.hostPlatform.isLinux;
           pkgsAt = self.packages.${pkgs.stdenv.hostPlatform.system};
@@ -241,7 +252,8 @@
           perftest = pkgsAt.perftest;
           bench-tools = pkgsAt.bench-tools;
           checks = self.checks.${pkgs.stdenv.hostPlatform.system};
-        } // lib.optionalAttrs isLinux {
+        }
+        // lib.optionalAttrs isLinux {
           thunderbolt-ibverbs = pkgsAt.thunderbolt-ibverbs;
           linux-thunderbolt = pkgsAt.linux-thunderbolt;
           linux-thunderbolt-dev = pkgsAt.linux-thunderbolt-dev;
@@ -249,9 +261,11 @@
           rdma-core-usb4 = pkgsAt.rdma-core-usb4;
           thunderbolt-ibverbs-linux-thunderbolt = pkgsAt.thunderbolt-ibverbs-linux-thunderbolt;
           vm-smoke.nixos = mkNixosVmSmoke pkgs;
-        });
+        }
+      );
 
-      devShells = forAllSystems (pkgs:
+      devShells = forAllSystems (
+        pkgs:
         let
           isLinux = pkgs.stdenv.hostPlatform.isLinux;
           pkgsAt = self.packages.${pkgs.stdenv.hostPlatform.system};
@@ -263,18 +277,42 @@
               pkgs.python3
               pkgsAt.perftest
               pkgsAt.bench-tools
-            ] ++ lib.optionals isLinux [
+            ]
+            ++ lib.optionals isLinux [
               pkgs.kmod
               pkgsAt.rdma-core-usb4
             ];
           };
-        });
+        }
+      );
 
-      overlays.default = final: prev: lib.optionalAttrs prev.stdenv.hostPlatform.isLinux {
-        rdma-core-usb4 = mkRdmaCoreUsb4 final;
-        thunderbolt-ibverbs =
-          final.linuxPackages.callPackage ./nix/module.nix { };
-      };
+      overlays.default =
+        final: prev:
+        let
+          isLinux = prev.stdenv.hostPlatform.isLinux;
+          rdmaCoreArgs = lib.optionalAttrs isLinux {
+            rdma-core-usb4 = final.rdma-core-usb4;
+          };
+        in
+        {
+          thunderbolt-ibverbs-bench-tools = final.callPackage ./nix/bench-tools.nix rdmaCoreArgs;
+          thunderbolt-ibverbs-perftest = final.callPackage ./nix/perftest.nix rdmaCoreArgs;
+        }
+        // lib.optionalAttrs isLinux (
+          let
+            thunderboltKernel = mkThunderboltKernel final;
+            thunderboltLinuxPackages = final.linuxPackagesFor thunderboltKernel;
+          in
+          {
+            linux-thunderbolt = thunderboltKernel;
+            linux-thunderbolt-dev = thunderboltKernel.dev;
+            linux-thunderbolt-modules = thunderboltKernel.modules;
+            linuxPackages_thunderbolt = thunderboltLinuxPackages;
+            rdma-core-usb4 = mkRdmaCoreUsb4 prev;
+            thunderbolt-ibverbs = final.linuxPackages.callPackage ./nix/module.nix { };
+            thunderbolt-ibverbs-linux-thunderbolt = thunderboltLinuxPackages.callPackage ./nix/module.nix { };
+          }
+        );
 
       lib.kernelPatches = thunderboltKernelPatches;
 

--- a/nix/apple-rdma-sdk.nix
+++ b/nix/apple-rdma-sdk.nix
@@ -1,0 +1,54 @@
+{ lib
+, bash
+, stdenvNoCC
+}:
+
+let
+  name = "apple-rdma-sdk-26.5";
+in
+derivation {
+  inherit name;
+  system = stdenvNoCC.hostPlatform.system;
+  builder = "${bash}/bin/bash";
+  args = [
+    "-c"
+    ''
+    cat >&2 <<'EOF'
+apple-rdma-sdk is an opaque fixed-output dependency.
+
+The Darwin bench/perftest packages need Xcode 26.5's Apple RDMA
+libibverbs headers, but those headers are not yet available from the
+packaged nixpkgs macOS SDK. Seed this exact fixed-output path into the
+store/cache instead of letting Hydra build it.
+
+Expected output contents:
+  $out/include/infiniband/verbs.h
+
+Expected recursive hash:
+  sha256-ULtTIGilQ3RFG3snbP2WLO39EOruJ9/LxNvspy26gr0=
+
+Temporary seed recipe on a Mac with Xcode 26.5:
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/include"
+  cp -R /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk/usr/include/infiniband "$tmp/include/"
+  nix hash path "$tmp"
+  nix store add-path --mode nar --hash-algo sha256 --name apple-rdma-sdk-26.5 "$tmp"
+
+TODO: replace this opaque fixed-output header bundle once macOS/Xcode 26.5
+SDK packaging exposes usr/include/infiniband.
+EOF
+    exit 1
+    ''
+  ];
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  outputHash = "sha256-ULtTIGilQ3RFG3snbP2WLO39EOruJ9/LxNvspy26gr0=";
+
+  preferLocalBuild = false;
+  allowSubstitutes = true;
+} // {
+  meta = with lib; {
+    description = "Opaque fixed-output Apple RDMA libibverbs header bundle";
+    platforms = platforms.darwin;
+  };
+}

--- a/nix/bench-tools.nix
+++ b/nix/bench-tools.nix
@@ -5,6 +5,7 @@
 , python3
 , source ? ../userspace/bench
 , appleCompat ? ./apple-compat
+, appleRdmaSdk ? null
 }:
 
 let
@@ -33,6 +34,8 @@ let
 
   cPrograms = if isDarwin then darwinPrograms else linuxPrograms;
 in
+assert lib.assertMsg (!isDarwin || appleRdmaSdk != null)
+  "bench-tools Darwin build requires appleRdmaSdk";
 stdenv.mkDerivation {
   pname =
     if isDarwin
@@ -62,6 +65,7 @@ stdenv.mkDerivation {
       for name in ${lib.concatStringsSep " " cPrograms}; do
         $CC -O2 -Wall -Wextra -std=gnu11 \
           -I${appleCompat} \
+          -I${appleRdmaSdk}/include \
           "$name.c" \
           -Wl,-undefined,dynamic_lookup \
           -o "$name"

--- a/nix/perftest.nix
+++ b/nix/perftest.nix
@@ -6,6 +6,7 @@
 , rdma-core-usb4 ? null
 , pciutils ? null
 , appleCompat ? ./apple-compat
+, appleRdmaSdk ? null
 }:
 
 let
@@ -17,12 +18,15 @@ let
   };
 in
 if stdenv.hostPlatform.isDarwin then
+  assert lib.assertMsg (appleRdmaSdk != null)
+    "perftest Darwin build requires appleRdmaSdk";
   # Build perftest on Apple Macs using nixpkgs' Darwin stdenv (no Xcode
-  # hardcoded paths, no __noChroot). Headers come from the apple-compat shim
-  # that provides Linux-style <infiniband/verbs.h>, <rdma/rdma_cma.h>, etc.;
-  # the linker is told to defer libibverbs symbol resolution to dyld via
-  # -undefined dynamic_lookup. Apple's RDMA stack provides those symbols at
-  # runtime on Macs with USB4-RDMA-capable hardware.
+  # hardcoded paths in this derivation). Core libibverbs headers come from the
+  # copied Xcode 26.5 Apple RDMA SDK; apple-compat only supplies Linux-style
+  # compatibility headers around that SDK surface. The linker is told to defer
+  # libibverbs symbol resolution to dyld via -undefined dynamic_lookup.
+  # Apple's RDMA stack provides those symbols at runtime on Macs with
+  # USB4-RDMA-capable hardware.
   stdenv.mkDerivation {
     pname = "perftest-apple-rdma";
     version = "26.01.5";
@@ -51,7 +55,7 @@ if stdenv.hostPlatform.isDarwin then
         --replace-fail 'src/host_memory.c src/mmap_memory.c' 'src/host_memory.c src/mmap_memory.c src/apple_raw_ethernet_stubs.c'
     '';
 
-    env.NIX_CFLAGS_COMPILE = "-I./apple-compat";
+    env.NIX_CFLAGS_COMPILE = "-I./apple-compat -I${appleRdmaSdk}/include";
     env.NIX_LDFLAGS = "-Wl,-undefined,dynamic_lookup";
 
     configureFlags = [


### PR DESCRIPTION
## Summary
- expose the practical Thunderbolt/RDMA package surface from `overlays.default`
- add prefixed overlay attrs for perftest and bench tools
- document downstream overlay composition

## Verification
- `nix flake check --no-build`

## Notes
This keeps `thunderbolt-ibverbs` standalone while making it easier for downstream flakes such as `nix-strix-halo` to compose its package set by overlay.