### PR TITLE
nix: fix Darwin perftest linker flags

### DIFF
--- a/nix/perftest.nix
+++ b/nix/perftest.nix
@@ -56,7 +56,7 @@ if stdenv.hostPlatform.isDarwin then
     '';
 
     env.NIX_CFLAGS_COMPILE = "-I./apple-compat -I${appleRdmaSdk}/include";
-    env.NIX_LDFLAGS = "-Wl,-undefined,dynamic_lookup";
+    env.LDFLAGS = "-Wl,-undefined,dynamic_lookup";
 
     configureFlags = [
       "--disable-cuda"


### PR DESCRIPTION
## Summary
- pass Darwin perftest dynamic lookup flags through Autoconf LDFLAGS instead of Nix cc-wrapper NIX_LDFLAGS
- keeps the opaque Xcode 26.5 Apple RDMA SDK header input from #6 unchanged

## Verification
- nix flake check --no-build --all-systems

This follows up the aarch64-darwin perftest configure failure in the PR #6 Hydra build.