### PR TITLE
release: bump to 0.2.0

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="thunderbolt-ibverbs"
-PACKAGE_VERSION="0.1.0"
+PACKAGE_VERSION="0.2.0"
 
 BUILT_MODULE_NAME[0]="thunderbolt_ibverbs"
 BUILT_MODULE_LOCATION[0]="kernel"

--- a/packaging/rpm/thunderbolt-ibverbs-dkms.spec
+++ b/packaging/rpm/thunderbolt-ibverbs-dkms.spec
@@ -51,5 +51,10 @@ fi
 /usr/src/%{modname}-%{version}/*
 
 %changelog
+* Thu May 28 2026 George Whewell <george@hellas.ai> - 0.2.0-1
+- v0.2.0: aarch64-darwin perftest and bench-tools, IOMMU-off transport
+  sweep results, Mac↔Linux UC SEND harness, additional kernel and
+  userspace fixes since 0.1.0.
+
 * Tue May 26 2026 George Whewell <george@hellas.ai> - 0.1.0-1
 - Initial DKMS source package.

--- a/packaging/rpm/usb4-rdma-provider.spec
+++ b/packaging/rpm/usb4-rdma-provider.spec
@@ -29,5 +29,8 @@ install -m 0644 %{_sourcedir}/usb4_rdma.driver %{buildroot}%{provider_etc_dir}/
 %{provider_etc_dir}/usb4_rdma.driver
 
 %changelog
+* Thu May 28 2026 George Whewell <george@hellas.ai> - 0.2.0-1
+- v0.2.0: version bump alongside thunderbolt-ibverbs-dkms 0.2.0.
+
 * Tue May 26 2026 George Whewell <george@hellas.ai> - 0.1.0-1
 - Initial release.


### PR DESCRIPTION
Bumps PACKAGE_VERSION in dkms.conf so the .deb/.rpm/.pkg.tar.zst artefacts produced for the v0.2.0 tag are labeled 0.2.0 rather than 0.1.0. Adds matching changelog entries to both RPM specs. Tagging v0.2.0 after this merges.