### PR TITLE
ci: usb4-rdma-provider .debs for ubuntu 22.04 / 24.04 (pytorch container path)

### DIFF
--- a/.github/workflows/release-artefacts.yml
+++ b/.github/workflows/release-artefacts.yml
@@ -19,31 +19,50 @@ concurrency:
 
 jobs:
   build:
-    name: build (${{ matrix.distro }})
+    name: build (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - distro: debian
+          - name: debian
+            distro: debian
             image: debian:sid
+            build_dkms: true
             dkms_glob: 'dist/thunderbolt-ibverbs-dkms_*.deb'
             rdma_glob: 'dist/usb4-rdma-provider_*.deb'
-            all_glob:  'dist/*.deb'
-          - distro: fedora
+            upload_glob: 'dist/*.deb'
+          - name: fedora
+            distro: fedora
             image: fedora:rawhide
+            build_dkms: true
             dkms_glob: 'dist/thunderbolt-ibverbs-dkms-*.rpm'
             rdma_glob: 'dist/usb4-rdma-provider-*.rpm'
-            all_glob:  'dist/*.rpm'
-          - distro: arch
+            upload_glob: 'dist/*.rpm'
+          - name: arch
+            distro: arch
             image: archlinux:latest
+            build_dkms: true
             dkms_glob: 'dist/thunderbolt-ibverbs-dkms-*.pkg.tar.zst'
             rdma_glob: 'dist/usb4-rdma-provider-*.pkg.tar.zst'
-            all_glob:  'dist/*.pkg.tar.zst'
+            upload_glob: 'dist/*.pkg.tar.zst'
+          - name: ubuntu-jammy
+            distro: ubuntu
+            image: ubuntu:22.04
+            build_dkms: false
+            rdma_glob: 'dist/usb4-rdma-provider_*~jammy_amd64.deb'
+            upload_glob: 'dist/usb4-rdma-provider_*~jammy_amd64.deb'
+          - name: ubuntu-noble
+            distro: ubuntu
+            image: ubuntu:24.04
+            build_dkms: false
+            rdma_glob: 'dist/usb4-rdma-provider_*~noble_amd64.deb'
+            upload_glob: 'dist/usb4-rdma-provider_*~noble_amd64.deb'
     steps:
       - uses: actions/checkout@v4
 
       - name: Build DKMS package in ${{ matrix.image }}
+        if: matrix.build_dkms
         run: |
           mkdir -p dist
           docker run --rm \
@@ -55,6 +74,7 @@ jobs:
 
       - name: Build rdma-provider package in ${{ matrix.image }}
         run: |
+          mkdir -p dist
           docker run --rm \
             -v "$PWD:/work" \
             -w /work \
@@ -63,6 +83,7 @@ jobs:
           ls -la dist/
 
       - name: Verify DKMS install in ${{ matrix.image }}
+        if: matrix.build_dkms
         run: |
           docker run --rm \
             -v "$PWD:/work" \
@@ -81,8 +102,8 @@ jobs:
       - name: Upload artefacts
         uses: actions/upload-artifact@v4
         with:
-          name: thunderbolt-ibverbs-${{ matrix.distro }}
-          path: ${{ matrix.all_glob }}
+          name: thunderbolt-ibverbs-${{ matrix.name }}
+          path: ${{ matrix.upload_glob }}
           if-no-files-found: error
 
   release:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ ibv_devices
 
 NCCL / UCX / perftest inside the container then see `usb4_rdma*` as a normal IB device.
 
+if you want a batteries-included image with vllm / llama.cpp / rdma-core-usb4 / perftest already baked in (heavier — a few GB), use the ibverbs-enabled docker images from [github.com/hellas-ai/nix-strix-halo](https://github.com/hellas-ai/nix-strix-halo).
+
 ## that sounds complicated, is there any easier way?
 sure, download and write the usb-bootable image from here, insert it into your machines, hit f11 while its booting to select the usb stick
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,31 @@ tell your agent- check out github.com/hellas-ai/thunderbolt-ibverbs and find out
 ## no, really, how do i use it?
 at a high level:
 
-load this kernel module- instructions differ by OS- this will create IB devices in `/dev/sys/class/infiniband` for each visible HCA:
-connect usb4 cables
-pass them and your gpu(s) to the ibverbs-enabled docker images from `nix-strix-halo`
+1. load the kernel module on the host (instructions per OS in [Install From GitHub Releases](#install-from-github-releases) below) — creates an IB device in `/sys/class/infiniband` per visible HCA
+2. connect usb4 cables between hosts
+3. run your workload against the device
+
+## run inside a stock pytorch / vllm / llama.cpp container
+
+the kernel module stays on the host. inside the container you just need our libibverbs provider so the stock `libibverbs.so` enumerates the device. drop the .deb in for your container's ubuntu codename:
+
+```sh
+docker run --rm -it \
+    --device=/dev/infiniband \
+    --cap-add=IPC_LOCK --ulimit memlock=-1 \
+    pytorch/pytorch:latest bash
+
+# inside the container — pick ~jammy for ubuntu 22.04, ~noble for 24.04:
+apt install -y ibverbs-utils \
+    https://github.com/hellas-ai/thunderbolt-ibverbs/releases/latest/download/usb4-rdma-provider_0.2.0~jammy_amd64.deb
+
+ibv_devices
+# device          	   node GUID
+# ------          	----------------
+# usb4_rdma0      	...
+```
+
+NCCL / UCX / perftest inside the container then see `usb4_rdma*` as a normal IB device.
 
 ## that sounds complicated, is there any easier way?
 sure, download and write the usb-bootable image from here, insert it into your machines, hit f11 while its booting to select the usb stick

--- a/packaging/rdma-core-patches/0001-providers-usb4_rdma-add-USB4-soft-RDMA-provider.patch
+++ b/packaging/rdma-core-patches/0001-providers-usb4_rdma-add-USB4-soft-RDMA-provider.patch
@@ -1,6 +1,6 @@
-From 0b38d4653e9471df61c3b161cc213a2f98c1e83c Mon Sep 17 00:00:00 2001
+From 64a125f47ebf75f51f138cb6ccbf5ecdc9382bbd Mon Sep 17 00:00:00 2001
 From: thunderbolt-ibverbs <ci@thunderbolt-ibverbs>
-Date: Sun, 17 May 2026 01:29:14 +0200
+Date: Sat, 30 May 2026 10:39:00 +0200
 Subject: [PATCH 1/3] providers/usb4_rdma: add USB4 soft-RDMA provider
 
 Out-of-tree provider for the usb4_rdma kernel module which exposes
@@ -9,12 +9,12 @@ devices.
 
 Source: https://github.com/hellas-ai/thunderbolt-ibverbs
 ---
- providers/usb4_rdma/CMakeLists.txt   |   3 +
- providers/usb4_rdma/usb4_rdma.c      | 335 +++++++++++++++++++++++++++
+ providers/usb4_rdma/CMakeLists.txt   |  14 +
+ providers/usb4_rdma/usb4_rdma.c      | 370 +++++++++++++++++++++++++++
  providers/usb4_rdma/usb4_rdma.driver |   1 +
- providers/usb4_rdma/usb4_rdma.h      |  26 +++
+ providers/usb4_rdma/usb4_rdma.h      |  26 ++
  providers/usb4_rdma/usb4_rdma_abi.h  |  15 ++
- 5 files changed, 380 insertions(+)
+ 5 files changed, 426 insertions(+)
  create mode 100644 providers/usb4_rdma/CMakeLists.txt
  create mode 100644 providers/usb4_rdma/usb4_rdma.c
  create mode 100644 providers/usb4_rdma/usb4_rdma.driver
@@ -23,19 +23,30 @@ Source: https://github.com/hellas-ai/thunderbolt-ibverbs
 
 diff --git a/providers/usb4_rdma/CMakeLists.txt b/providers/usb4_rdma/CMakeLists.txt
 new file mode 100644
-index 0000000..c032062
+index 0000000..c45c710
 --- /dev/null
 +++ b/providers/usb4_rdma/CMakeLists.txt
-@@ -0,0 +1,3 @@
+@@ -0,0 +1,14 @@
++# rdma-core v55+ grew two extra parameters on internal helpers the provider
++# uses: ibv_cmd_get_context (new fd_arr parameter at position 4) and
++# ibv_cmd_reg_dmabuf_mr (new driver command-buffer parameter at the end).
++# Provider source defaults to the v55+ form; here we set guards so the older
++# form is used when building against pre-v55 rdma-core (e.g. Ubuntu 22.04
++# ships v39, Ubuntu 24.04 ships v50). The exact cutoff is v55.
++if(PACKAGE_VERSION VERSION_LESS "55")
++    add_definitions(-DUSB4_RDMA_OLD_GET_CONTEXT=1)
++    add_definitions(-DUSB4_RDMA_OLD_REG_DMABUF_MR=1)
++endif()
++
 +rdma_provider(usb4_rdma
 +  usb4_rdma.c
 +)
 diff --git a/providers/usb4_rdma/usb4_rdma.c b/providers/usb4_rdma/usb4_rdma.c
 new file mode 100644
-index 0000000..6afd084
+index 0000000..9c34ff8
 --- /dev/null
 +++ b/providers/usb4_rdma/usb4_rdma.c
-@@ -0,0 +1,359 @@
+@@ -0,0 +1,370 @@
 +// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 +/*
 + * usb4_rdma userspace verbs provider — Tier 1 skeleton.
@@ -271,8 +282,13 @@ index 0000000..6afd084
 +	if (!vmr)
 +		return NULL;
 +
++#ifdef USB4_RDMA_OLD_REG_DMABUF_MR
++	/* rdma-core < v55 (Ubuntu 22.04/24.04 etc.) — no trailing driver_data. */
++	rv = ibv_cmd_reg_dmabuf_mr(pd, offset, length, iova, fd, access, vmr);
++#else
 +	rv = ibv_cmd_reg_dmabuf_mr(pd, offset, length, iova, fd, access, vmr,
 +				   NULL);
++#endif
 +	if (rv) {
 +		free(vmr);
 +		errno = rv;
@@ -327,8 +343,14 @@ index 0000000..6afd084
 +	if (!ctx)
 +		return NULL;
 +
++#ifdef USB4_RDMA_OLD_GET_CONTEXT
++	/* rdma-core < v55 — no async event channel param. */
++	rv = ibv_cmd_get_context(&ctx->base, &cmd, sizeof(cmd),
++				 &resp, sizeof(resp));
++#else
 +	rv = ibv_cmd_get_context(&ctx->base, &cmd, sizeof(cmd),
 +				 NULL, &resp, sizeof(resp));
++#endif
 +	if (rv) {
 +		verbs_uninit_context(&ctx->base);
 +		free(ctx);
@@ -455,5 +477,6 @@ index 0000000..5fd8c2f
 +#define USB4_RDMA_ABI_VERSION 1
 +
 +#endif /* USB4_RDMA_ABI_H */
---
+-- 
 2.53.0
+

--- a/packaging/rdma-core-patches/0002-CMakeLists.txt-build-the-usb4_rdma-provider.patch
+++ b/packaging/rdma-core-patches/0002-CMakeLists.txt-build-the-usb4_rdma-provider.patch
@@ -1,6 +1,6 @@
-From 567b981eb9306da0f970769a7ebab16ef8991b97 Mon Sep 17 00:00:00 2001
+From 45cdeef137e9576ced14c81cfdfa0ca0dd7e2b1c Mon Sep 17 00:00:00 2001
 From: thunderbolt-ibverbs <ci@thunderbolt-ibverbs>
-Date: Sun, 17 May 2026 01:29:14 +0200
+Date: Sat, 30 May 2026 10:39:00 +0200
 Subject: [PATCH 2/3] CMakeLists.txt: build the usb4_rdma provider
 
 ---
@@ -16,8 +16,9 @@ index 718b7d2..b2b9f0c 100644
  add_subdirectory(providers/rxe/man)
  add_subdirectory(providers/siw)
 +add_subdirectory(providers/usb4_rdma)
-
+ 
  add_subdirectory(libibmad)
  add_subdirectory(libibnetdisc)
---
+-- 
 2.53.0
+

--- a/packaging/rdma-core-patches/0003-libibverbs-verbs.h-declare-verbs_provider_usb4_rdma.patch
+++ b/packaging/rdma-core-patches/0003-libibverbs-verbs.h-declare-verbs_provider_usb4_rdma.patch
@@ -1,6 +1,6 @@
-From b1f99e9908c2d3d8ab70008765e8ac1e47e0a60f Mon Sep 17 00:00:00 2001
+From 3043fc974d36dd07a926f206b66cbcd8d42c9862 Mon Sep 17 00:00:00 2001
 From: thunderbolt-ibverbs <ci@thunderbolt-ibverbs>
-Date: Sun, 17 May 2026 01:29:14 +0200
+Date: Sat, 30 May 2026 10:39:00 +0200
 Subject: [PATCH 3/3] libibverbs/verbs.h: declare verbs_provider_usb4_rdma
 
 Required for the static-archive build path (libibverbs/all_providers.c)
@@ -22,5 +22,6 @@ index 36d120e..1212662 100644
  extern const struct verbs_device_ops verbs_provider_vmw_pvrdma;
  extern const struct verbs_device_ops verbs_provider_ionic;
  extern const struct verbs_device_ops verbs_provider_all;
---
+-- 
 2.53.0
+

--- a/tools/ci/distro-package-rdma.sh
+++ b/tools/ci/distro-package-rdma.sh
@@ -1,24 +1,30 @@
 #!/usr/bin/env bash
-# Build the usb4_rdma libibverbs userspace provider by applying our patches to
-# rdma-core upstream, building with CMake/Ninja inside the target distro
-# container, then packaging the resulting .so + driver hint as a native
-# .deb/.rpm/.pkg.tar.zst. Building inside each distro's container gives a
-# provider .so whose libibverbs PABI version matches that distro's libibverbs.
+# Build the usb4_rdma libibverbs userspace provider and package it as a native
+# .deb / .rpm / .pkg.tar.zst. The provider .so is built against the same
+# rdma-core source as the target distro's libibverbs so the PABI version
+# matches and apt/dnf/pacman can install the package as a drop-in.
+#
+#   debian      → upstream rdma-core v62.0 (Debian sid ships current)
+#   ubuntu      → distro's own rdma-core via apt-get source (handles 22.04+
+#                 where stock libibverbs PABI is older than v62.0)
+#   fedora|arch → upstream rdma-core v62.0
 
 set -euo pipefail
 
 usage() {
 	cat <<'EOF'
 Usage:
-  tools/ci/distro-package-rdma.sh debian|fedora|arch
+  tools/ci/distro-package-rdma.sh debian|ubuntu|fedora|arch
 
-Outputs the produced .deb / .rpm / .pkg.tar.zst into OUT_DIR.
+Outputs the produced .deb / .rpm / .pkg.tar.zst into OUT_DIR. For ubuntu the
+filename includes the distro codename (e.g. usb4-rdma-provider_0.2.0~jammy_amd64.deb).
 
 Environment:
-  TBV_VERSION       Override version (default reads PACKAGE_VERSION from dkms.conf).
+  TBV_VERSION       Override base version (default reads PACKAGE_VERSION from dkms.conf).
   OUT_DIR           Output directory (default $PWD/dist).
   WORK_DIR          Scratch directory (default mktemp).
-  RDMA_CORE_TAG     rdma-core git tag to build against (default v62.0).
+  RDMA_CORE_TAG     rdma-core git tag for the upstream-source distros (default v62.0).
+                    Ignored for ubuntu (uses apt-get source).
   TBV_SKIP_DEPS     Skip distro deps install (default 0).
   TBV_SKIP_BUILD    Skip the rdma-core build step (used by the arch builder
                     re-exec; default 0).
@@ -28,14 +34,27 @@ EOF
 distro="${1:-}"
 case "${distro:-}" in
 	-h|--help) usage; exit 0 ;;
-	debian|fedora|arch) ;;
+	debian|ubuntu|fedora|arch) ;;
 	"") usage >&2; exit 1 ;;
 	*) printf 'error: unsupported distro: %s\n' "$distro" >&2; exit 1 ;;
 esac
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
-version="${TBV_VERSION:-$(awk -F'"' '/^PACKAGE_VERSION=/ { print $2; exit }' "$repo_root/dkms.conf")}"
-[[ -n "$version" ]] || { printf 'error: could not determine version\n' >&2; exit 1; }
+base_version="${TBV_VERSION:-$(awk -F'"' '/^PACKAGE_VERSION=/ { print $2; exit }' "$repo_root/dkms.conf")}"
+[[ -n "$base_version" ]] || { printf 'error: could not determine version\n' >&2; exit 1; }
+
+# Ubuntu builds encode the codename in the version so different ubuntu releases'
+# .debs don't collide on the GitHub Releases page and apt picks the right one.
+codename=""
+if [[ "$distro" == "ubuntu" && -r /etc/os-release ]]; then
+	codename="$(. /etc/os-release && printf '%s' "${VERSION_CODENAME:-${UBUNTU_CODENAME:-unknown}}")"
+fi
+if [[ -n "$codename" ]]; then
+	version="${base_version}~${codename}"
+else
+	version="$base_version"
+fi
+
 out_dir="${OUT_DIR:-$repo_root/dist}"
 work_dir="${WORK_DIR:-$(mktemp -d)}"
 rdma_core_tag="${RDMA_CORE_TAG:-v62.0}"
@@ -57,6 +76,22 @@ install_deps() {
 				libudev-dev libssl-dev ninja-build patch patchelf pkg-config \
 				python3-docutils python3-pyelftools
 			;;
+		ubuntu)
+			export DEBIAN_FRONTEND=noninteractive
+			# Enable deb-src so apt-get source can fetch rdma-core. Ubuntu 22.04
+			# uses /etc/apt/sources.list; 24.04 uses /etc/apt/sources.list.d/ubuntu.sources.
+			if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
+				sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+			else
+				sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
+			fi
+			apt-get update -qq
+			apt-get install -y -qq --no-install-recommends \
+				build-essential ca-certificates cmake dpkg-dev \
+				libcap-dev libnl-3-dev libnl-route-3-dev libsystemd-dev \
+				libudev-dev libssl-dev ninja-build patch patchelf pkg-config \
+				python3-docutils python3-pyelftools
+			;;
 		fedora)
 			dnf install -y -q --setopt=install_weak_deps=False \
 				cmake gcc gcc-c++ git libcap-devel libnl3-devel libudev-devel \
@@ -71,23 +106,49 @@ install_deps() {
 	esac
 }
 
+# Populate $src with the rdma-core source tree, patched. Strategy depends on
+# distro: ubuntu uses its own packaged source so PABI matches stock libibverbs;
+# everything else uses upstream v62.0.
+fetch_rdma_core_source() {
+	local src="$1"
+	rm -rf "$src"
+	if [[ "$distro" == "ubuntu" ]]; then
+		mkdir -p "$src"
+		( cd "$src" && apt-get source rdma-core >/dev/null )
+		# apt-get source extracts to ./rdma-core-<ver>/; move it up so $src
+		# itself is the source root.
+		local extracted
+		extracted="$(find "$src" -maxdepth 1 -type d -name 'rdma-core-*' -print -quit)"
+		[[ -n "$extracted" ]] ||
+			{ printf 'error: apt-get source did not extract rdma-core\n' >&2; exit 1; }
+		mv "$extracted"/* "$extracted"/.[!.]* "$src"/ 2>/dev/null || true
+		rmdir "$extracted"
+	else
+		git clone --depth 1 --branch "$rdma_core_tag" \
+			https://github.com/linux-rdma/rdma-core "$src"
+	fi
+}
+
 build_provider() {
 	[[ "$skip_build" == "1" ]] && return 0
 	local src="$work_dir/rdma-core"
 	local build="$src/build"
 
-	if [[ ! -d "$src" ]]; then
-		git clone --depth 1 --branch "$rdma_core_tag" \
-			https://github.com/linux-rdma/rdma-core "$src"
-	fi
+	fetch_rdma_core_source "$src"
 
+	# Our patches were generated against v62.0 but apply (with offset/fuzz) to
+	# older rdma-core down to at least v39 (Ubuntu 22.04). Patch 1 only adds
+	# new files; 2 and 3 absorb hunk drift automatically.
 	for p in "$repo_root/packaging/rdma-core-patches"/*.patch; do
 		( cd "$src" && patch --silent -p1 < "$p" )
 	done
 
 	rm -rf "$build"
 	mkdir "$build"
-	( cd "$build" && cmake -GNinja -DNO_PYVERBS=1 .. >/dev/null && ninja )
+	# NO_MAN_PAGES because Ubuntu's apt-get source tree ships a pandoc cache
+	# that doesn't match all manpage inputs after our patches; we don't need
+	# manpages in the artefact anyway.
+	( cd "$build" && cmake -GNinja -DNO_PYVERBS=1 -DNO_MAN_PAGES=1 .. >/dev/null && ninja )
 
 	local so
 	so="$(find "$build/lib" -maxdepth 1 -name 'libusb4_rdma-rdmav*.so' -print -quit)"
@@ -211,7 +272,7 @@ install_deps
 build_provider
 
 case "$distro" in
-	debian) build_deb ;;
+	debian|ubuntu) build_deb ;;
 	fedora) build_rpm ;;
 	arch)   build_arch ;;
 esac

--- a/userspace/usb4_rdma/CMakeLists.txt
+++ b/userspace/usb4_rdma/CMakeLists.txt
@@ -1,3 +1,14 @@
+# rdma-core v55+ grew two extra parameters on internal helpers the provider
+# uses: ibv_cmd_get_context (new fd_arr parameter at position 4) and
+# ibv_cmd_reg_dmabuf_mr (new driver command-buffer parameter at the end).
+# Provider source defaults to the v55+ form; here we set guards so the older
+# form is used when building against pre-v55 rdma-core (e.g. Ubuntu 22.04
+# ships v39, Ubuntu 24.04 ships v50). The exact cutoff is v55.
+if(PACKAGE_VERSION VERSION_LESS "55")
+    add_definitions(-DUSB4_RDMA_OLD_GET_CONTEXT=1)
+    add_definitions(-DUSB4_RDMA_OLD_REG_DMABUF_MR=1)
+endif()
+
 rdma_provider(usb4_rdma
   usb4_rdma.c
 )

--- a/userspace/usb4_rdma/usb4_rdma.c
+++ b/userspace/usb4_rdma/usb4_rdma.c
@@ -233,8 +233,13 @@ static struct ibv_mr *usb4_rdma_reg_dmabuf_mr(struct ibv_pd *pd,
 	if (!vmr)
 		return NULL;
 
+#ifdef USB4_RDMA_OLD_REG_DMABUF_MR
+	/* rdma-core < v55 (Ubuntu 22.04/24.04 etc.) — no trailing driver_data. */
+	rv = ibv_cmd_reg_dmabuf_mr(pd, offset, length, iova, fd, access, vmr);
+#else
 	rv = ibv_cmd_reg_dmabuf_mr(pd, offset, length, iova, fd, access, vmr,
 				   NULL);
+#endif
 	if (rv) {
 		free(vmr);
 		errno = rv;
@@ -289,8 +294,14 @@ static struct verbs_context *usb4_rdma_alloc_context(struct ibv_device *base_dev
 	if (!ctx)
 		return NULL;
 
+#ifdef USB4_RDMA_OLD_GET_CONTEXT
+	/* rdma-core < v55 — no async event channel param. */
+	rv = ibv_cmd_get_context(&ctx->base, &cmd, sizeof(cmd),
+				 &resp, sizeof(resp));
+#else
 	rv = ibv_cmd_get_context(&ctx->base, &cmd, sizeof(cmd),
 				 NULL, &resp, sizeof(resp));
+#endif
 	if (rv) {
 		verbs_uninit_context(&ctx->base);
 		free(ctx);


### PR DESCRIPTION
## Summary

Ship `usb4-rdma-provider` .debs that apt-install cleanly inside stock PyTorch / vllm / llama.cpp containers (Ubuntu 22.04 + 24.04 based). Replaces the previous "you have to use my heavy Docker images" path with `apt install ./usb4-rdma-provider_0.2.0~jammy_amd64.deb`.

## What changed

- **GH Actions matrix**: two new entries `ubuntu-jammy` (image: ubuntu:22.04) and `ubuntu-noble` (image: ubuntu:24.04). Build provider only (DKMS package is arch-independent, the Debian sid build covers all deb-family hosts).
- **`tools/ci/distro-package-rdma.sh`**: new `ubuntu` distro mode. Uses \`apt-get source rdma-core\` instead of cloning upstream v62.0 so the resulting provider PABI matches the distro's stock libibverbs (rdmav34 on 22.04, rdmav39 on 24.04 etc). Codename auto-detected from \`/etc/os-release\` and encoded in the .deb version (\`0.2.0~jammy\`) so multiple Ubuntu artefacts coexist on the Releases page.
- **`userspace/usb4_rdma/CMakeLists.txt` + `usb4_rdma.c`**: backport. `ibv_cmd_get_context` and `ibv_cmd_reg_dmabuf_mr` each grew an extra parameter in rdma-core v55. Gated with `#ifdef USB4_RDMA_OLD_*` driven by a `PACKAGE_VERSION VERSION_LESS "55"` check in the provider's CMakeLists. Defaults to the modern signatures so Debian sid / Fedora rawhide / Arch builds are unchanged.
- **Patches regenerated** from the updated userspace source.
- **README**: new "run inside a stock pytorch container" section with the new install command.

## Test plan

- [x] `ubuntu:22.04` container: build provider + install .deb in `pytorch/pytorch:latest`; `ibv_devices` enumerates `usb4_rdma9` PORT_ACTIVE. Verified on strix-1.
- [x] `distro-install.sh` verification on Ubuntu 22.04 (ldd lib + symbol resolution pass).
- [ ] Same verification on Ubuntu 24.04 (build path is identical, expecting it to pass in CI).
- [ ] Debian sid build path unchanged — should keep producing `usb4-rdma-provider_0.2.0_amd64.deb` exactly as before.
- [ ] Fedora / Arch builds unchanged.

## User-visible behaviour after merge

Release pages get two new artefacts per version:
```
usb4-rdma-provider_0.2.0~jammy_amd64.deb
usb4-rdma-provider_0.2.0~noble_amd64.deb
```

Stock PyTorch users can now do:
```sh
docker run --device=/dev/infiniband --cap-add=IPC_LOCK --ulimit memlock=-1 \
    pytorch/pytorch:latest bash
apt install -y https://github.com/hellas-ai/thunderbolt-ibverbs/releases/latest/download/usb4-rdma-provider_0.2.0~jammy_amd64.deb
```