### PR TITLE
release: bump to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ docker run --rm -it \
 
 # inside the container — pick ~jammy for ubuntu 22.04, ~noble for 24.04:
 apt install -y ibverbs-utils \
-    https://github.com/hellas-ai/thunderbolt-ibverbs/releases/latest/download/usb4-rdma-provider_0.2.0~jammy_amd64.deb
+    https://github.com/hellas-ai/thunderbolt-ibverbs/releases/latest/download/usb4-rdma-provider_0.2.1~jammy_amd64.deb
 
 ibv_devices
 # device          	   node GUID

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="thunderbolt-ibverbs"
-PACKAGE_VERSION="0.2.0"
+PACKAGE_VERSION="0.2.1"
 
 BUILT_MODULE_NAME[0]="thunderbolt_ibverbs"
 BUILT_MODULE_LOCATION[0]="kernel"

--- a/packaging/rpm/thunderbolt-ibverbs-dkms.spec
+++ b/packaging/rpm/thunderbolt-ibverbs-dkms.spec
@@ -51,6 +51,11 @@ fi
 /usr/src/%{modname}-%{version}/*
 
 %changelog
+* Sat May 30 2026 George Whewell <george@hellas.ai> - 0.2.1-1
+- v0.2.1: no DKMS-side changes; release cut alongside Ubuntu 22.04 and
+  24.04 usb4-rdma-provider .debs so PyTorch / vllm / llama.cpp users can
+  apt-install the provider directly inside stock containers.
+
 * Thu May 28 2026 George Whewell <george@hellas.ai> - 0.2.0-1
 - v0.2.0: aarch64-darwin perftest and bench-tools, IOMMU-off transport
   sweep results, Mac↔Linux UC SEND harness, additional kernel and

--- a/packaging/rpm/usb4-rdma-provider.spec
+++ b/packaging/rpm/usb4-rdma-provider.spec
@@ -29,6 +29,11 @@ install -m 0644 %{_sourcedir}/usb4_rdma.driver %{buildroot}%{provider_etc_dir}/
 %{provider_etc_dir}/usb4_rdma.driver
 
 %changelog
+* Sat May 30 2026 George Whewell <george@hellas.ai> - 0.2.1-1
+- v0.2.1: Ubuntu 22.04 / 24.04 .deb variants added alongside this rpm.
+  Provider C backported with ifdef guards for rdma-core API drift
+  pre-v55. No functional change for Fedora users.
+
 * Thu May 28 2026 George Whewell <george@hellas.ai> - 0.2.0-1
 - v0.2.0: version bump alongside thunderbolt-ibverbs-dkms 0.2.0.
 


### PR DESCRIPTION
Bumps PACKAGE_VERSION + matching RPM changelog entries + README install URL so the v0.2.1 release artefacts (including the new ubuntu-jammy / ubuntu-noble .debs) are labeled 0.2.1. Tagging v0.2.1 after this merges.