### PR TITLE
readme: fix usb4-rdma-provider deb URL (~ → .)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ docker run --rm -it \
     --cap-add=IPC_LOCK --ulimit memlock=-1 \
     pytorch/pytorch:latest bash
 
-# inside the container — pick ~jammy for ubuntu 22.04, ~noble for 24.04:
+# inside the container — pick .jammy for ubuntu 22.04, .noble for 24.04:
 apt install -y ibverbs-utils \
-    https://github.com/hellas-ai/thunderbolt-ibverbs/releases/latest/download/usb4-rdma-provider_0.2.1~jammy_amd64.deb
+    https://github.com/hellas-ai/thunderbolt-ibverbs/releases/latest/download/usb4-rdma-provider_0.2.1.jammy_amd64.deb
 
 ibv_devices
 # device          	   node GUID


### PR DESCRIPTION
GitHub Releases mangles `~` in uploaded asset filenames to `.`, so the URL in the README install command 404s. The .debs work fine via apt internally; just the URL needs the matching filename.