### PR TITLE
nix: update perftest to 26.04.17

### DIFF
--- a/nix/apple-compat/infiniband/verbs.h
+++ b/nix/apple-compat/infiniband/verbs.h
@@ -3,6 +3,8 @@
 
 #include_next <infiniband/verbs.h>
 
+#include <errno.h>
+
 #ifndef __always_inline
 #define __always_inline __attribute__((__always_inline__)) inline
 #endif
@@ -67,6 +69,25 @@ struct ibv_srq_init_attr_ex {
 
 struct ibv_flow;
 struct ibv_flow_attr;
+
+#ifndef IBV_PARENT_DOMAIN_INIT_ATTR_PD
+#define IBV_PARENT_DOMAIN_INIT_ATTR_PD (1 << 0)
+struct ibv_parent_domain_init_attr {
+	struct ibv_pd *pd;
+	struct ibv_td *td;
+	uint32_t comp_mask;
+};
+
+static inline struct ibv_pd *
+ibv_alloc_parent_domain(struct ibv_context *context,
+			struct ibv_parent_domain_init_attr *attr)
+{
+	(void)context;
+	(void)attr;
+	errno = ENOTSUP;
+	return NULL;
+}
+#endif
 
 #ifndef HAVE_EX_ODP
 #define check_odp_support(ctx, user_param) 0

--- a/nix/apple-compat/sched.h
+++ b/nix/apple-compat/sched.h
@@ -1,0 +1,68 @@
+#ifndef PERFTEST_APPLE_COMPAT_SCHED_H
+#define PERFTEST_APPLE_COMPAT_SCHED_H
+
+#include_next <sched.h>
+
+#ifdef __APPLE__
+#include <errno.h>
+#include <stddef.h>
+#include <string.h>
+#include <sys/types.h>
+
+#ifndef CPU_SETSIZE
+#define CPU_SETSIZE 1024
+#endif
+
+typedef struct {
+	unsigned long bits[CPU_SETSIZE / (8 * sizeof(unsigned long))];
+} cpu_set_t;
+
+static inline void CPU_ZERO(cpu_set_t *set)
+{
+	memset(set, 0, sizeof(*set));
+}
+
+static inline void CPU_SET(int cpu, cpu_set_t *set)
+{
+	if (cpu >= 0 && cpu < CPU_SETSIZE)
+		set->bits[cpu / (8 * sizeof(unsigned long))] |=
+			1UL << (cpu % (8 * sizeof(unsigned long)));
+}
+
+static inline int CPU_COUNT(const cpu_set_t *set)
+{
+	int count = 0;
+
+	for (size_t i = 0; i < sizeof(set->bits) / sizeof(set->bits[0]); i++)
+		count += __builtin_popcountl(set->bits[i]);
+
+	return count;
+}
+
+static inline int sched_setaffinity(pid_t pid, size_t cpusetsize,
+				    const cpu_set_t *mask)
+{
+	(void)pid;
+	(void)cpusetsize;
+	(void)mask;
+	errno = ENOTSUP;
+	return -1;
+}
+
+static inline int sched_getaffinity(pid_t pid, size_t cpusetsize,
+				    cpu_set_t *mask)
+{
+	(void)pid;
+	(void)cpusetsize;
+	CPU_ZERO(mask);
+	errno = ENOTSUP;
+	return -1;
+}
+
+static inline int sched_getcpu(void)
+{
+	return -1;
+}
+#endif
+
+#endif

--- a/nix/apple-compat/sys/mman.h
+++ b/nix/apple-compat/sys/mman.h
@@ -1,0 +1,16 @@
+#ifndef PERFTEST_APPLE_COMPAT_SYS_MMAN_H
+#define PERFTEST_APPLE_COMPAT_SYS_MMAN_H
+
+#include_next <sys/mman.h>
+
+#ifdef __APPLE__
+#ifndef MAP_HUGETLB
+#define MAP_HUGETLB 0
+#endif
+
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#endif
+
+#endif

--- a/nix/perftest.nix
+++ b/nix/perftest.nix
@@ -13,8 +13,8 @@ let
   perftest-src = fetchFromGitHub {
     owner = "linux-rdma";
     repo = "perftest";
-    rev = "perftest-26.01.5";
-    hash = "sha256-WcFOaG5Lzn87EZCZ8w6UTI6qtfX1wOtvF/lxSDwjEq4=";
+    rev = "26.04.17";
+    hash = "sha256-oNvzQubmslZ4JUNww/wvWd54JDsDLamCDlorHWlNtaY=";
   };
 in
 if stdenv.hostPlatform.isDarwin then
@@ -27,7 +27,7 @@ if stdenv.hostPlatform.isDarwin then
   # dyld pick up Apple's RDMA stack at runtime.
   stdenv.mkDerivation {
     pname = "perftest-apple-rdma";
-    version = "26.01.5";
+    version = "26.04.17";
     src = perftest-src;
 
     nativeBuildInputs = [ autoreconfHook ];
@@ -60,7 +60,7 @@ if stdenv.hostPlatform.isDarwin then
         --replace-fail 'case IBV_LINK_LAYER_ETHERNET:' 'case IBV_LINK_LAYER_ETHERNET: case IBV_LINK_LAYER_THUNDERBOLT:' \
         --replace-fail 'params->link_type = port_attr.link_layer;' 'params->link_type = (port_attr.link_layer == IBV_LINK_LAYER_THUNDERBOLT) ? IBV_LINK_LAYER_ETHERNET : port_attr.link_layer;'
       substituteInPlace Makefile.am \
-        --replace-fail 'src/host_memory.c src/mmap_memory.c' 'src/host_memory.c src/mmap_memory.c src/apple_raw_ethernet_stubs.c'
+        --replace-fail 'src/host_memory.c src/host_validation.c src/mmap_memory.c' 'src/host_memory.c src/host_validation.c src/mmap_memory.c src/apple_raw_ethernet_stubs.c'
     '';
 
     # apple-compat shim still supplies a few helper headers (byteswap.h etc.)
@@ -74,10 +74,11 @@ if stdenv.hostPlatform.isDarwin then
     env.LDFLAGS = "-lrdma -Wl,-undefined,dynamic_lookup";
 
     configureFlags = [
-      "--disable-cuda"
+      "--disable-cudart"
       "--disable-rocm"
       "--disable-neuron"
       "--disable-ibv_wr_api"
+      "--disable-cq_ex"
     ];
 
     meta = with lib; {
@@ -91,7 +92,7 @@ else
   # Linux build against our rdma-core-usb4 provider.
   stdenv.mkDerivation {
     pname = "perftest";
-    version = "26.01.5";
+    version = "26.04.17";
     src = perftest-src;
 
     nativeBuildInputs = [ autoreconfHook pkg-config ];
@@ -107,9 +108,10 @@ else
     '';
 
     configureFlags = [
-      "--disable-cuda"
+      "--disable-cudart"
       "--disable-rocm"
       "--disable-neuron"
+      "--disable-cq_ex"
     ];
 
     meta = with lib; {


### PR DESCRIPTION
## Summary
- update linux-rdma/perftest to 26.04.17 and refresh the fixed-output Nix hash
- replace the stale `--disable-cuda` configure flag with upstream's current `--disable-cudart` flag
- disable upstream's new CQ-ex path for now; our usb4 provider implements the classic CQ verbs path
- update the Darwin perftest patch/shims for upstream host validation, CPU affinity, hugepage mmap, and parent-domain API references

## Changelog notes
- 26.04.17 enables CQ-ex support when available; this PR passes `--disable-cq_ex` because the provider does not expose CQ-ex operations yet.
- New host validation and NUMA/CPU-affinity code pulled in Linux-specific APIs; the Darwin build now supplies compatibility shims instead of carrying a larger source patch.
- GID auto-selection changed upstream, but `tbv-perftest` still passes `--gid-index` explicitly, so no runner change was needed.
- RDMA-CM changes in the release do not affect our current default non-RDMA-CM path.

## Validation
- `nix flake check --print-build-logs`
- `nix build .#packages.aarch64-darwin.perftest --print-build-logs`
- `nix run .#tbv-perftest -- --help`
- Strix smoke:
  `nix run .#tbv-perftest -- --hosts strix-1,strix-2 --dev usb4_rdma5 --gid-index 1 --no-rail-check --timeout 45 --tag perftest-26.04.17-smoke --csv /tmp/perftest-26.04.17-smoke.csv --jsonl /tmp/perftest-26.04.17-smoke.jsonl --only bw.ib_write_bw.size4096.qps1 --only lat.ib_write_lat.size64 --directions forward --stop-on-fail`

Strix smoke passed both selected cases on `usb4_rdma5` with two active 20Gb/s rails on each host. Results: `ib_write_bw` 4096B/qps1 avg 3.78 Gbps; `ib_write_lat` 64B typical 6.55 us, avg 6.67 us, p99 9.04 us.

Runner warnings: `strix-1` and `strix-2` currently have different local module hashes and IOMMU modes; this did not block the smoke run.
