### PR TITLE
nix: set georgewhewell as maintainer

### DIFF
--- a/bench/perftest.nix
+++ b/bench/perftest.nix
@@ -201,6 +201,7 @@ let
     '';
     meta = {
       description = plan.description;
+      maintainers = with lib.maintainers; [ georgewhewell ];
       platforms = lib.platforms.linux;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
           testingKernel = pkgs.linuxPackages_testing.kernel;
           kernelPatches = (testingKernel.passthru.kernelPatches or [ ]) ++ thunderboltKernelPatches;
         in
-        testingKernel.override {
+        (testingKernel.override {
           argsOverride = {
             pname = "linux-thunderbolt";
             version = linuxSrcVersion;
@@ -62,7 +62,11 @@
             src = linux-src;
             inherit kernelPatches;
           };
-        };
+        }).overrideAttrs (old: {
+          meta = (old.meta or { }) // {
+            maintainers = with pkgs.lib.maintainers; [ georgewhewell ];
+          };
+        });
       mkThunderboltLinuxPackages = pkgs: pkgs.linuxPackagesFor (mkThunderboltKernel pkgs);
       rdmaCoreUsb4Patches = [
         ./packaging/rdma-core-patches/0001-providers-usb4_rdma-add-USB4-soft-RDMA-provider.patch
@@ -74,6 +78,9 @@
         pkgs.rdma-core.overrideAttrs (old: {
           pname = "rdma-core-usb4";
           patches = (old.patches or [ ]) ++ rdmaCoreUsb4Patches;
+          meta = (old.meta or { }) // {
+            maintainers = with pkgs.lib.maintainers; [ georgewhewell ];
+          };
         });
       mkScriptSyntaxCheck =
         pkgs:
@@ -105,6 +112,10 @@
             mkdir -p "$out"
             runHook postInstall
           '';
+
+          meta = {
+            maintainers = with pkgs.lib.maintainers; [ georgewhewell ];
+          };
         };
       mkProtoSmoke =
         pkgs:
@@ -129,6 +140,10 @@
             mkdir -p "$out"
             runHook postInstall
           '';
+
+          meta = {
+            maintainers = with pkgs.lib.maintainers; [ georgewhewell ];
+          };
         };
       mkNixosVmSmoke =
         pkgs:
@@ -138,6 +153,9 @@
         in
         pkgs.testers.runNixOSTest {
           name = "thunderbolt-ibverbs-vm-smoke";
+          meta = {
+            maintainers = with pkgs.lib.maintainers; [ georgewhewell ];
+          };
 
           nodes.machine =
             { pkgs, ... }:
@@ -186,6 +204,10 @@
             mkdir -p "$out"
             runHook postInstall
           '';
+
+          meta = {
+            maintainers = with pkgs.lib.maintainers; [ georgewhewell ];
+          };
         };
     in
     {
@@ -248,6 +270,10 @@
           tbv-perftest = {
             type = "app";
             program = lib.getExe pkgsAt.tbv-perftest;
+            meta = {
+              description = "Run the Thunderbolt/USB4 RDMA perftest benchmark matrix";
+              maintainers = with pkgs.lib.maintainers; [ georgewhewell ];
+            };
           };
         }
       );
@@ -311,6 +337,9 @@
               pkgs.kmod
               pkgsAt.rdma-core-usb4
             ];
+            meta = {
+              maintainers = with pkgs.lib.maintainers; [ georgewhewell ];
+            };
           };
         }
       );

--- a/module.nix
+++ b/module.nix
@@ -169,6 +169,9 @@
 
       echo "thunderbolt-ibverbs-check: ok"
     '';
+    meta = {
+      maintainers = with lib.maintainers; [ georgewhewell ];
+    };
   };
 
   reloadHelper = pkgs.writeShellApplication {
@@ -281,6 +284,9 @@
         ${checkHelper}/bin/thunderbolt-ibverbs-check
       fi
     '';
+    meta = {
+      maintainers = with lib.maintainers; [ georgewhewell ];
+    };
   };
 in {
   options.hardware."thunderbolt-ibverbs" = {

--- a/nix/bench-tools.nix
+++ b/nix/bench-tools.nix
@@ -117,6 +117,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Thunderbolt/USB4 RDMA bench programs (libibverbs C tools + perftest helper scripts)";
     license = licenses.mit;
+    maintainers = with maintainers; [ georgewhewell ];
     platforms = if isDarwin then platforms.darwin else platforms.linux;
   };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Thunderbolt/USB4 host-to-host RDMA verbs kernel module";
     license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/nix/perftest.nix
+++ b/nix/perftest.nix
@@ -85,6 +85,7 @@ if stdenv.hostPlatform.isDarwin then
       description = "OFED InfiniBand performance tests (linked against macOS 26 SDK librdma)";
       homepage = "https://github.com/linux-rdma/perftest";
       license = licenses.bsd2;
+      maintainers = with maintainers; [ georgewhewell ];
       platforms = platforms.darwin;
     };
   }
@@ -118,6 +119,7 @@ else
       description = "OFED InfiniBand performance tests (linked against rdma-core-usb4)";
       homepage = "https://github.com/linux-rdma/perftest";
       license = licenses.bsd2;
+      maintainers = with maintainers; [ georgewhewell ];
       platforms = platforms.linux;
     };
   }


### PR DESCRIPTION
## Summary
- set `meta.maintainers = [ lib.maintainers.georgewhewell ]` on local Nix derivations
- cover package overrides, check derivations, helper scripts, the NixOS VM test, dev shell, and app metadata
- keep existing metadata such as descriptions, licenses, and platforms intact

## Validation
- `git diff --check`
- `nix flake check --print-build-logs`
- evaluated representative Linux/Darwin package, check, devShell, and app outputs to confirm the first maintainer resolves to `georgewhewell`
