### PR TITLE
readme: fix hydra badge rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # thunderbolt-ibverbs
 
-[![Hydra module][hydra-module-badge]][hydra-module]
-[hydra-module-badge]: https://img.shields.io/endpoint?label=hydra%20module&url=https%3A%2F%2Fhydra.hellas.ai%2Fjob%2Fhellas%2Fthunderbolt-ibverbs%2Fx86_64-linux.thunderbolt-ibverbs%2Fshield
-[hydra-module]: https://hydra.hellas.ai/job/hellas/thunderbolt-ibverbs/x86_64-linux.thunderbolt-ibverbs
+[![Hydra module](https://img.shields.io/endpoint?label=hydra%20module&url=https%3A%2F%2Fhydra.hellas.ai%2Fjob%2Fhellas%2Fthunderbolt-ibverbs%2Fx86_64-linux.thunderbolt-ibverbs%2Fshield)](https://hydra.hellas.ai/job/hellas/thunderbolt-ibverbs/x86_64-linux.thunderbolt-ibverbs)
 
 *** WARNING ***
 


### PR DESCRIPTION
## Summary
- replace the Hydra badge reference-style markdown with inline badge markdown
- GitHub's renderer was treating the reference definitions as literal README text

## Validation
- `git diff --check`
- rendered the README header through GitHub's markdown API and confirmed it emits an `<img>` for the badge
- verified the Shields endpoint title is `hydra module: passing`
