### PR TITLE
readme: reduce hydra badge cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # thunderbolt-ibverbs
 
-[![Hydra module](https://img.shields.io/endpoint?label=hydra%20module&url=https%3A%2F%2Fhydra.hellas.ai%2Fjob%2Fhellas%2Fthunderbolt-ibverbs%2Fx86_64-linux.thunderbolt-ibverbs%2Fshield)](https://hydra.hellas.ai/job/hellas/thunderbolt-ibverbs/x86_64-linux.thunderbolt-ibverbs)
+[![Hydra module](https://img.shields.io/endpoint?label=hydra%20module&url=https%3A%2F%2Fhydra.hellas.ai%2Fjob%2Fhellas%2Fthunderbolt-ibverbs%2Fx86_64-linux.thunderbolt-ibverbs%2Fshield&cacheSeconds=60)](https://hydra.hellas.ai/job/hellas/thunderbolt-ibverbs/x86_64-linux.thunderbolt-ibverbs)
 
 *** WARNING ***
 


### PR DESCRIPTION
## Summary
- add `cacheSeconds=60` to the README Hydra Shields badge URL
- leaves the Hydra job target unchanged

## Validation
- `git diff --check`
- Hydra shield endpoint returns `passing`
- Shields badge URL returns `200 image/svg+xml` with title `hydra module: passing`