### PR TITLE
ci: add Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      nix-inputs:
+        patterns:
+          - "*"
+        group-by: "dependency-name"


### PR DESCRIPTION
## Summary
- add daily Dependabot updates for the root Nix flake
- group Nix input updates by dependency name

## Testing
- not run; configuration-only change