### PR TITLE
kernel: clean up patch stack exports

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,14 +22,12 @@
       portableLocalThunderboltKernelPatches = import ./kernel-workflow/patches/local-portable.nix;
       portableThunderboltKernelPatches = import ./kernel-workflow/patches/portable.nix;
       integrationDebugThunderboltKernelPatches = import ./kernel-workflow/patches/local-integration-debug.nix;
-      localThunderboltKernelPatches = import ./kernel-workflow/patches;
+      integrationThunderboltKernelPatches = import ./kernel-workflow/patches/local.nix;
       kernelPatchSets = {
-        kernelPatches = localThunderboltKernelPatches;
-        portableKernelPatches = portableThunderboltKernelPatches;
+        kernelPatches = portableThunderboltKernelPatches;
+        integrationKernelPatches = integrationThunderboltKernelPatches;
         upstreamKernelPatches = upstreamThunderboltKernelPatches;
         portableLocalKernelPatches = portableLocalThunderboltKernelPatches;
-        integrationDebugKernelPatches = integrationDebugThunderboltKernelPatches;
-        kernelPatchesForIntegrationTree = localThunderboltKernelPatches;
       };
       linuxSystems = [ "x86_64-linux" ];
       darwinSystems = [ "aarch64-darwin" ];
@@ -64,7 +62,7 @@
         pkgs:
         let
           testingKernel = pkgs.linuxPackages_testing.kernel;
-          kernelPatches = (testingKernel.passthru.kernelPatches or [ ]) ++ localThunderboltKernelPatches;
+          kernelPatches = (testingKernel.passthru.kernelPatches or [ ]) ++ integrationThunderboltKernelPatches;
         in
         (testingKernel.override {
           argsOverride = {

--- a/kernel-workflow/patches/README.md
+++ b/kernel-workflow/patches/README.md
@@ -1,6 +1,14 @@
 # Kernel Patches
 
-This directory carries these patch sets:
+This directory carries two ready-to-use patch stacks:
+
+- `portable.nix`: stock-kernel stack. It applies the Thunderbolt maintainer-tree
+  commits from `upstream-thunderbolt-next.nix`, then the project-local patches
+  from `local-portable.nix`.
+- `local.nix`: integration-tree stack for the flake's `linux-thunderbolt`
+  package, which builds from `westeri/thunderbolt.git`.
+
+The component lists are:
 
 - `upstream-thunderbolt-next.nix`: Thunderbolt maintainer-tree commits that are
   not guaranteed to be present in a stock kernel.
@@ -8,30 +16,24 @@ This directory carries these patch sets:
   layer on a stock kernel.
 - `local-integration-debug.nix`: debug patches that are only carried for the
   `westeri/thunderbolt.git` integration-tree kernel.
-- `local.nix`: all local patches for the integration-tree kernel.
-- `portable.nix`: upstream maintainer-tree commits plus local patches that
-  apply on a stock kernel.
+- `default.nix`: imports `portable.nix`.
 
-`default.nix` intentionally preserves the historical local-only patch stack for
-existing consumers. Use `portable.nix` or the `portableKernelPatches` flake
-export to patch a normal kernel, for example `pkgs.linuxPackages_latest`.
-`portable.nix` excludes `local-integration-debug.nix` because that patch does
-not apply cleanly to the stock kernel after the upstream layer.
+Use `portable.nix` or the `kernelPatches` flake export to patch a normal kernel,
+for example `pkgs.linuxPackages_latest`. `portable.nix` excludes
+`local-integration-debug.nix` because that patch does not apply cleanly to the
+stock kernel after the upstream layer.
 
 The flake's `linux-thunderbolt` package uses `westeri/thunderbolt.git` as its
-kernel source, so it applies only `local.nix`. Applying
-`upstream-thunderbolt-next.nix` there would double-apply the same maintainer
-commits.
+kernel source, so it applies `local.nix`. Applying
+`upstream-thunderbolt-next.nix` there would apply the same maintainer commits
+twice.
 
 Flake exports:
 
-- `lib.kernelPatches`: historical local-only integration-tree stack.
-- `lib.portableKernelPatches`: portable stock-kernel stack.
+- `lib.kernelPatches`: portable stock-kernel stack.
+- `lib.integrationKernelPatches`: local patches for the integration-tree kernel.
 - `lib.upstreamKernelPatches`: maintainer-tree delta only.
 - `lib.portableLocalKernelPatches`: local stock-kernel-compatible patches.
-- `lib.integrationDebugKernelPatches`: integration-tree-only debug patches.
-- `lib.kernelPatchesForIntegrationTree`: descriptive alias for
-  `lib.kernelPatches`.
 
 The same names are exposed under `legacyPackages.${system}` for NixOS configs
 that cannot conveniently read flake `lib` attributes.

--- a/kernel-workflow/patches/default.nix
+++ b/kernel-workflow/patches/default.nix
@@ -1,1 +1,1 @@
-import ./local.nix
+import ./portable.nix


### PR DESCRIPTION
## Summary
- make `kernel-workflow/patches` default to the portable stock-kernel stack
- export `kernelPatches` for stock kernels and `integrationKernelPatches` for the `westeri/thunderbolt.git` integration kernel
- tighten the patch-stack README around the current stack layout

## Checks
- `nix eval --json .#legacyPackages.x86_64-linux.kernelPatches --apply builtins.length` -> 26
- `nix eval --json .#legacyPackages.x86_64-linux.integrationKernelPatches --apply builtins.length` -> 6
- `nix build .#checks.x86_64-linux.portable-kernel-patches --print-build-logs`
- `nix build .#checks.x86_64-linux.script-syntax --print-build-logs`