### PR TITLE
kernel: carry XDomain foundation patches

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
       integrationThunderboltKernelPatches = import ./kernel-workflow/patches/local.nix;
       kernelPatchSets = {
         kernelPatches = portableThunderboltKernelPatches;
+        portableKernelPatches = portableThunderboltKernelPatches;
         integrationKernelPatches = integrationThunderboltKernelPatches;
         upstreamKernelPatches = upstreamThunderboltKernelPatches;
         portableLocalKernelPatches = portableLocalThunderboltKernelPatches;

--- a/kernel-workflow/patches/0009-thunderbolt-xdomain-lane-bonding-module-param.patch
+++ b/kernel-workflow/patches/0009-thunderbolt-xdomain-lane-bonding-module-param.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: georgewhewell <georgerw@gmail.com>
+Date: Fri, 5 Jun 2026 02:25:00 +0200
+Subject: [PATCH] thunderbolt: add XDomain lane bonding module parameter
+
+Add a debug module parameter that can skip the automatic XDomain lane
+bonding handshake while leaving the default behavior unchanged.
+
+This is useful when investigating non-standard topologies where the two
+domains report asymmetric link state through an intermediate hub.
+---
+ drivers/thunderbolt/xdomain.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+index 7e0d0641242a..47fd0994b919 100644
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -53,6 +53,11 @@ static const char * const state_names[] = {
+ 	[XDOMAIN_STATE_ERROR] = "ERROR",
+ };
+ 
++static bool xdomain_lane_bonding = true;
++module_param_named(xdomain_lane_bonding, xdomain_lane_bonding, bool, 0644);
++MODULE_PARM_DESC(xdomain_lane_bonding,
++		 "enable automatic XDomain lane bonding (default: true)");
++
+ struct xdomain_request_work {
+ 	struct work_struct work;
+ 	struct tb_xdp_header *pkg;
+@@ -1726,10 +1731,14 @@ static void tb_xdomain_state_work(struct work_struct *work)
+ 			tb_xdomain_failed(xd);
+ 		} else {
+ 			tb_xdomain_queue_properties_changed(xd);
+-			if (xd->bonding_possible)
+-				tb_xdomain_queue_link_status(xd);
+-			else
+-				tb_xdomain_queue_properties(xd);
++			if (xd->bonding_possible && xdomain_lane_bonding) {
++				tb_xdomain_queue_link_status(xd);
++			} else {
++				if (xd->bonding_possible)
++					dev_dbg(&xd->dev,
++						"XDomain lane bonding disabled by module parameter\n");
++				tb_xdomain_queue_properties(xd);
++			}
+ 		}
+ 		break;
+ 
+-- 
+2.53.0

--- a/kernel-workflow/patches/0010-thunderbolt-trace-XDomain-route-matching.patch
+++ b/kernel-workflow/patches/0010-thunderbolt-trace-XDomain-route-matching.patch
@@ -1,0 +1,576 @@
+From 5b4a9b9c071dfa82f90b5518f9f4cec0781b2e7d Mon Sep 17 00:00:00 2001
+From: georgewhewell <georgerw@gmail.com>
+Date: Sat, 6 Jun 2026 14:16:52 +0200
+Subject: [PATCH] thunderbolt: trace XDomain route matching
+
+Signed-off-by: georgewhewell <georgerw@gmail.com>
+---
+ drivers/thunderbolt/icm.c     |   5 +
+ drivers/thunderbolt/tb.h      |   1 +
+ drivers/thunderbolt/xdomain.c | 297 +++++++++++++++++++++++++++++++++-
+ 3 files changed, 295 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/thunderbolt/icm.c b/drivers/thunderbolt/icm.c
+index 10fefac3b1d9..2956cd1772cb 100644
+--- a/drivers/thunderbolt/icm.c
++++ b/drivers/thunderbolt/icm.c
+@@ -732,6 +732,11 @@ static void add_xdomain(struct tb_switch *sw, u64 route,
+ 
+ static void update_xdomain(struct tb_xdomain *xd, u64 route, u8 link)
+ {
++	if (tb_xdomain_debug_enabled())
++		dev_info(&xd->dev, "XDomain ICM update route old=%llx new=%llx link old=%u new=%u depth=%u remote=%pUb\n",
++			 xd->route, route, xd->link, link, xd->depth,
++			 xd->remote_uuid);
++
+ 	xd->link = link;
+ 	xd->route = route;
+ 	xd->is_unplugged = false;
+diff --git a/drivers/thunderbolt/tb.h b/drivers/thunderbolt/tb.h
+index ec9192b61bc0..a68c53f21257 100644
+--- a/drivers/thunderbolt/tb.h
++++ b/drivers/thunderbolt/tb.h
+@@ -1257,6 +1257,7 @@ static inline u64 tb_downstream_route(struct tb_port *port)
+ }
+ 
+ bool tb_is_xdomain_enabled(void);
++bool tb_xdomain_debug_enabled(void);
+ bool tb_xdomain_handle_request(struct tb *tb, enum tb_cfg_pkg_type type,
+ 			       const void *buf, size_t size);
+ struct tb_xdomain *tb_xdomain_alloc(struct tb *tb, struct device *parent,
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+index 86b2f7474670..61d316af3b47 100644
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -63,6 +63,11 @@ static bool tb_xdomain_enabled = true;
+ module_param_named(xdomain, tb_xdomain_enabled, bool, 0444);
+ MODULE_PARM_DESC(xdomain, "allow XDomain protocol (default: true)");
+ 
++static bool xdomain_debug;
++module_param_named(xdomain_debug, xdomain_debug, bool, 0644);
++MODULE_PARM_DESC(xdomain_debug,
++		 "log XDomain discovery packets and route matching decisions");
++
+ /*
+  * Serializes access to the properties and protocol handlers below. If
+  * you need to take both this lock and the struct tb_xdomain lock, take
+@@ -82,11 +87,65 @@ static const uuid_t tb_xdp_uuid =
+ 	UUID_INIT(0xb638d70e, 0x42ff, 0x40bb,
+ 		  0x97, 0xc2, 0x90, 0xe2, 0xc0, 0xb2, 0xff, 0x07);
+ 
++static u64 tb_xdp_route(const struct tb_xdp_header *hdr)
++{
++	return ((u64)(hdr->xd_hdr.route_hi & ~BIT(31)) << 32) |
++	       hdr->xd_hdr.route_lo;
++}
++
++static u8 tb_xdp_sequence(const struct tb_xdp_header *hdr)
++{
++	return (hdr->xd_hdr.length_sn & TB_XDOMAIN_SN_MASK) >>
++		TB_XDOMAIN_SN_SHIFT;
++}
++
++static u16 tb_xdp_length(const struct tb_xdp_header *hdr)
++{
++	return hdr->xd_hdr.length_sn & TB_XDOMAIN_LENGTH_MASK;
++}
++
++static const char *tb_xdp_type_name(enum tb_xdp_type type)
++{
++	switch (type) {
++	case UUID_REQUEST_OLD:
++		return "UUID_REQUEST_OLD";
++	case UUID_RESPONSE:
++		return "UUID_RESPONSE";
++	case PROPERTIES_REQUEST:
++		return "PROPERTIES_REQUEST";
++	case PROPERTIES_RESPONSE:
++		return "PROPERTIES_RESPONSE";
++	case PROPERTIES_CHANGED_REQUEST:
++		return "PROPERTIES_CHANGED_REQUEST";
++	case PROPERTIES_CHANGED_RESPONSE:
++		return "PROPERTIES_CHANGED_RESPONSE";
++	case ERROR_RESPONSE:
++		return "ERROR_RESPONSE";
++	case UUID_REQUEST:
++		return "UUID_REQUEST";
++	case LINK_STATE_STATUS_REQUEST:
++		return "LINK_STATE_STATUS_REQUEST";
++	case LINK_STATE_STATUS_RESPONSE:
++		return "LINK_STATE_STATUS_RESPONSE";
++	case LINK_STATE_CHANGE_REQUEST:
++		return "LINK_STATE_CHANGE_REQUEST";
++	case LINK_STATE_CHANGE_RESPONSE:
++		return "LINK_STATE_CHANGE_RESPONSE";
++	default:
++		return "UNKNOWN";
++	}
++}
++
+ bool tb_is_xdomain_enabled(void)
+ {
+ 	return tb_xdomain_enabled && tb_acpi_is_xdomain_allowed();
+ }
+ 
++bool tb_xdomain_debug_enabled(void)
++{
++	return xdomain_debug;
++}
++
+ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ 			     const struct ctl_pkg *pkg)
+ {
+@@ -98,19 +157,76 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ 		const struct tb_xdp_header *res_hdr = pkg->buffer;
+ 		const struct tb_xdp_header *req_hdr = req->request;
+ 
+-		if (pkg->frame.size < req->response_size / 4)
++		if (pkg->frame.size < req->response_size / 4) {
++			if (xdomain_debug)
++				pr_info_ratelimited("thunderbolt xdomain: match drop short response req_type=%s(%#x) frame_size=%u expected_cmp=%zu response_size=%zu\n",
++						    tb_xdp_type_name(req_hdr->type),
++						    req_hdr->type,
++						    pkg->frame.size,
++						    req->response_size / 4,
++						    req->response_size);
+ 			return false;
++		}
+ 
+ 		/* Make sure route matches */
+ 		if ((res_hdr->xd_hdr.route_hi & ~BIT(31)) !=
+-		     req_hdr->xd_hdr.route_hi)
++		     req_hdr->xd_hdr.route_hi) {
++			if (xdomain_debug)
++				pr_info_ratelimited("thunderbolt xdomain: match drop route_hi req_type=%s(%#x) res_type=%s(%#x) req_route=%llx res_route=%llx req_seq=%u res_seq=%u frame_size=%u\n",
++						    tb_xdp_type_name(req_hdr->type),
++						    req_hdr->type,
++						    tb_xdp_type_name(res_hdr->type),
++						    res_hdr->type,
++						    tb_xdp_route(req_hdr),
++						    tb_xdp_route(res_hdr),
++						    tb_xdp_sequence(req_hdr),
++						    tb_xdp_sequence(res_hdr),
++						    pkg->frame.size);
+ 			return false;
+-		if ((res_hdr->xd_hdr.route_lo) != req_hdr->xd_hdr.route_lo)
++		}
++		if ((res_hdr->xd_hdr.route_lo) != req_hdr->xd_hdr.route_lo) {
++			if (xdomain_debug)
++				pr_info_ratelimited("thunderbolt xdomain: match drop route_lo req_type=%s(%#x) res_type=%s(%#x) req_route=%llx res_route=%llx req_seq=%u res_seq=%u frame_size=%u\n",
++						    tb_xdp_type_name(req_hdr->type),
++						    req_hdr->type,
++						    tb_xdp_type_name(res_hdr->type),
++						    res_hdr->type,
++						    tb_xdp_route(req_hdr),
++						    tb_xdp_route(res_hdr),
++						    tb_xdp_sequence(req_hdr),
++						    tb_xdp_sequence(res_hdr),
++						    pkg->frame.size);
+ 			return false;
++		}
+ 
+ 		/* Check that the XDomain protocol matches */
+-		if (!uuid_equal(&res_hdr->uuid, &req_hdr->uuid))
++		if (!uuid_equal(&res_hdr->uuid, &req_hdr->uuid)) {
++			if (xdomain_debug)
++				pr_info_ratelimited("thunderbolt xdomain: match drop protocol uuid req_type=%s(%#x) res_type=%s(%#x) route=%llx req_uuid=%pUb res_uuid=%pUb frame_size=%u\n",
++						    tb_xdp_type_name(req_hdr->type),
++						    req_hdr->type,
++						    tb_xdp_type_name(res_hdr->type),
++						    res_hdr->type,
++						    tb_xdp_route(req_hdr),
++						    &req_hdr->uuid,
++						    &res_hdr->uuid,
++						    pkg->frame.size);
+ 			return false;
++		}
++
++		if (xdomain_debug)
++			pr_info_ratelimited("thunderbolt xdomain: match accept req_type=%s(%#x) res_type=%s(%#x) route=%llx req_seq=%u res_seq=%u req_len=%u res_len=%u frame_size=%u response_size=%zu\n",
++					    tb_xdp_type_name(req_hdr->type),
++					    req_hdr->type,
++					    tb_xdp_type_name(res_hdr->type),
++					    res_hdr->type,
++					    tb_xdp_route(req_hdr),
++					    tb_xdp_sequence(req_hdr),
++					    tb_xdp_sequence(res_hdr),
++					    tb_xdp_length(req_hdr),
++					    tb_xdp_length(res_hdr),
++					    pkg->frame.size,
++					    req->response_size);
+ 
+ 		return true;
+ 	}
+@@ -278,21 +394,38 @@ static int tb_xdp_uuid_request(struct tb_ctl *ctl, u64 route, int retry,
+ 	memset(&req, 0, sizeof(req));
+ 	tb_xdp_fill_header(&req.hdr, route, retry % 4, UUID_REQUEST,
+ 			   sizeof(req));
++	if (xdomain_debug)
++		pr_info("thunderbolt xdomain: tx UUID request route=%llx seq=%u retry=%d\n",
++			route, tb_xdp_sequence(&req.hdr), retry);
+ 
+ 	memset(&res, 0, sizeof(res));
+ 	ret = __tb_xdomain_request(ctl, &req, sizeof(req),
+ 				   TB_CFG_PKG_XDOMAIN_REQ, &res, sizeof(res),
+ 				   TB_CFG_PKG_XDOMAIN_RESP,
+ 				   XDOMAIN_DEFAULT_TIMEOUT);
+-	if (ret)
++	if (ret) {
++		if (xdomain_debug)
++			pr_info("thunderbolt xdomain: UUID request route=%llx failed ret=%d\n",
++				route, ret);
+ 		return ret;
++	}
+ 
+ 	ret = tb_xdp_handle_error(&res.err);
+-	if (ret)
++	if (ret) {
++		if (xdomain_debug)
++			pr_info("thunderbolt xdomain: UUID response route=%llx error=%d type=%s(%#x) res_route=%llx seq=%u\n",
++				route, ret, tb_xdp_type_name(res.hdr.type),
++				res.hdr.type, tb_xdp_route(&res.hdr),
++				tb_xdp_sequence(&res.hdr));
+ 		return ret;
++	}
+ 
+ 	uuid_copy(uuid, &res.src_uuid);
+ 	*remote_route = (u64)res.src_route_hi << 32 | res.src_route_lo;
++	if (xdomain_debug)
++		pr_info("thunderbolt xdomain: rx UUID response req_route=%llx res_route=%llx remote_route=%llx seq=%u uuid=%pUb\n",
++			route, tb_xdp_route(&res.hdr), *remote_route,
++			tb_xdp_sequence(&res.hdr), uuid);
+ 
+ 	return 0;
+ }
+@@ -309,6 +442,9 @@ static int tb_xdp_uuid_response(struct tb_ctl *ctl, u64 route, u8 sequence,
+ 	uuid_copy(&res.src_uuid, uuid);
+ 	res.src_route_hi = upper_32_bits(route);
+ 	res.src_route_lo = lower_32_bits(route);
++	if (xdomain_debug)
++		pr_info("thunderbolt xdomain: tx UUID response route=%llx seq=%u uuid=%pUb\n",
++			route, sequence, uuid);
+ 
+ 	return __tb_xdomain_response(ctl, &res, sizeof(res),
+ 				     TB_CFG_PKG_XDOMAIN_RESP);
+@@ -323,6 +459,9 @@ static int tb_xdp_error_response(struct tb_ctl *ctl, u64 route, u8 sequence,
+ 	tb_xdp_fill_header(&res.hdr, route, sequence, ERROR_RESPONSE,
+ 			   sizeof(res));
+ 	res.error = error;
++	if (xdomain_debug)
++		pr_info("thunderbolt xdomain: tx error response route=%llx seq=%u error=%d\n",
++			route, sequence, error);
+ 
+ 	return __tb_xdomain_response(ctl, &res, sizeof(res),
+ 				     TB_CFG_PKG_XDOMAIN_RESP);
+@@ -353,16 +492,41 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 	data_len = 0;
+ 
+ 	do {
++		if (xdomain_debug)
++			pr_info("thunderbolt xdomain: tx properties request route=%llx seq=%u retry=%d offset=%u src=%pUb dst=%pUb\n",
++				route, tb_xdp_sequence(&req.hdr), retry,
++				req.offset, &req.src_uuid, &req.dst_uuid);
++
+ 		ret = __tb_xdomain_request(ctl, &req, sizeof(req),
+ 					   TB_CFG_PKG_XDOMAIN_REQ, res,
+ 					   total_size, TB_CFG_PKG_XDOMAIN_RESP,
+ 					   XDOMAIN_DEFAULT_TIMEOUT);
+-		if (ret)
++		if (ret) {
++			if (xdomain_debug)
++				pr_info("thunderbolt xdomain: properties request route=%llx offset=%u failed ret=%d\n",
++					route, req.offset, ret);
+ 			goto err;
++		}
++
++		if (xdomain_debug)
++			pr_info("thunderbolt xdomain: rx properties candidate req_route=%llx res_route=%llx req_seq=%u res_seq=%u type=%s(%#x) xdp_len=%u frame_src=%pUb frame_dst=%pUb offset=%u data_len=%u gen=%u\n",
++				route, tb_xdp_route(&res->hdr),
++				tb_xdp_sequence(&req.hdr),
++				tb_xdp_sequence(&res->hdr),
++				tb_xdp_type_name(res->hdr.type), res->hdr.type,
++				tb_xdp_length(&res->hdr), &res->src_uuid,
++				&res->dst_uuid, res->offset, res->data_length,
++				res->generation);
+ 
+ 		ret = tb_xdp_handle_error(&res->err);
+-		if (ret)
++		if (ret) {
++			if (xdomain_debug)
++				pr_info("thunderbolt xdomain: properties response route=%llx offset=%u protocol error ret=%d type=%s(%#x)\n",
++					route, req.offset, ret,
++					tb_xdp_type_name(res->hdr.type),
++					res->hdr.type);
+ 			goto err;
++		}
+ 
+ 		/*
+ 		 * Package length includes the whole payload without the
+@@ -372,6 +536,13 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 		len = res->hdr.xd_hdr.length_sn & TB_XDOMAIN_LENGTH_MASK;
+ 		if (len < sizeof(*res) / 4) {
+ 			ret = -EINVAL;
++			if (xdomain_debug)
++				pr_info("thunderbolt xdomain: properties response too short route=%llx offset=%u xdp_len=%u min=%zu type=%s(%#x) src=%pUb dst=%pUb\n",
++					route, req.offset, len,
++					sizeof(*res) / 4,
++					tb_xdp_type_name(res->hdr.type),
++					res->hdr.type, &res->src_uuid,
++					&res->dst_uuid);
+ 			goto err;
+ 		}
+ 
+@@ -380,6 +551,11 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 
+ 		if (res->offset != req.offset) {
+ 			ret = -EINVAL;
++			if (xdomain_debug)
++				pr_info("thunderbolt xdomain: properties response offset mismatch route=%llx req=%u res=%u chunk_len=%u data_len=%u src=%pUb dst=%pUb\n",
++					route, req.offset, res->offset, len,
++					res->data_length, &res->src_uuid,
++					&res->dst_uuid);
+ 			goto err;
+ 		}
+ 
+@@ -391,6 +567,11 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 			data_len = res->data_length;
+ 			if (data_len > TB_XDP_PROPERTIES_MAX_LENGTH) {
+ 				ret = -E2BIG;
++				if (xdomain_debug)
++					pr_info("thunderbolt xdomain: properties response too large route=%llx offset=%u chunk_len=%u data_len=%u max=%u src=%pUb dst=%pUb\n",
++						route, req.offset, len, data_len,
++						TB_XDP_PROPERTIES_MAX_LENGTH,
++						&res->src_uuid, &res->dst_uuid);
+ 				goto err;
+ 			}
+ 
+@@ -403,6 +584,13 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 
+ 		if (req.offset + len > data_len)
+ 			len = data_len - req.offset;
++
++		if (xdomain_debug)
++			pr_info("thunderbolt xdomain: accepted properties chunk route=%llx offset=%u chunk_len=%u data_len=%u next_offset=%u gen=%u src=%pUb dst=%pUb\n",
++				route, req.offset, len, data_len,
++				req.offset + len, res->generation,
++				&res->src_uuid, &res->dst_uuid);
++
+ 		memcpy(data + req.offset, res->data, len * 4);
+ 		req.offset += len;
+ 	} while (!data_len || req.offset < data_len);
+@@ -429,12 +617,24 @@ static int tb_xdp_properties_response(struct tb *tb, struct tb_ctl *ctl,
+ 	u16 len;
+ 	int ret;
+ 
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain rx properties request packet_route=%llx xd_route=%llx state=%s seq=%u offset=%u src=%pUb dst=%pUb local=%pUb remote=%pUb\n",
++			 tb_xdp_route(&req->hdr), xd->route,
++			 state_names[xd->state], sequence, req->offset,
++			 &req->src_uuid, &req->dst_uuid, xd->local_uuid,
++			 xd->remote_uuid);
++
+ 	/*
+ 	 * Currently we expect all requests to be directed to us. The
+ 	 * protocol supports forwarding, though which we might add
+ 	 * support later on.
+ 	 */
+ 	if (!uuid_equal(xd->local_uuid, &req->dst_uuid)) {
++		if (xdomain_debug)
++			dev_info(&xd->dev, "XDomain properties request unknown domain packet_route=%llx xd_route=%llx seq=%u offset=%u src=%pUb dst=%pUb local=%pUb remote=%pUb\n",
++				 tb_xdp_route(&req->hdr), xd->route, sequence,
++				 req->offset, &req->src_uuid, &req->dst_uuid,
++				 xd->local_uuid, xd->remote_uuid);
+ 		tb_xdp_error_response(ctl, xd->route, sequence,
+ 				      ERROR_UNKNOWN_DOMAIN);
+ 		return 0;
+@@ -443,6 +643,11 @@ static int tb_xdp_properties_response(struct tb *tb, struct tb_ctl *ctl,
+ 	mutex_lock(&xd->lock);
+ 
+ 	if (req->offset >= xd->local_property_block_len) {
++		if (xdomain_debug)
++			dev_info(&xd->dev, "XDomain properties request bad offset packet_route=%llx xd_route=%llx seq=%u offset=%u block_len=%u src=%pUb dst=%pUb\n",
++				 tb_xdp_route(&req->hdr), xd->route, sequence,
++				 req->offset, xd->local_property_block_len,
++				 &req->src_uuid, &req->dst_uuid);
+ 		mutex_unlock(&xd->lock);
+ 		return -EINVAL;
+ 	}
+@@ -466,6 +671,12 @@ static int tb_xdp_properties_response(struct tb *tb, struct tb_ctl *ctl,
+ 	uuid_copy(&res->dst_uuid, &req->src_uuid);
+ 	memcpy(res->data, &xd->local_property_block[req->offset], len * 4);
+ 
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain tx properties response route=%llx seq=%u offset=%u chunk_len=%u block_len=%u gen=%u src=%pUb dst=%pUb\n",
++			 xd->route, sequence, res->offset, len,
++			 res->data_length, res->generation, &res->src_uuid,
++			 &res->dst_uuid);
++
+ 	mutex_unlock(&xd->lock);
+ 
+ 	ret = __tb_xdomain_response(ctl, res, total_size,
+@@ -727,6 +938,11 @@ static void update_property_block(struct tb_xdomain *xd)
+ 		xd->local_property_block = block;
+ 		xd->local_property_block_len = block_len;
+ 		xd->local_property_block_gen = xdomain_property_block_gen;
++		if (xdomain_debug)
++			dev_info(&xd->dev, "XDomain local properties rebuilt route=%llx block_len=%d gen=%u max_hopid=%u\n",
++				 xd->route, block_len,
++				 xd->local_property_block_gen,
++				 xd->local_max_hopid);
+ 	}
+ 
+ out_unlock:
+@@ -737,6 +953,10 @@ static void update_property_block(struct tb_xdomain *xd)
+ static void start_handshake(struct tb_xdomain *xd)
+ {
+ 	xd->state = XDOMAIN_STATE_INIT;
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain start handshake route=%llx local=%pUb remote=%pUb needs_uuid=%d\n",
++			 xd->route, xd->local_uuid, xd->remote_uuid,
++			 xd->needs_uuid);
+ 	queue_delayed_work(xd->tb->wq, &xd->state_work,
+ 			   msecs_to_jiffies(XDOMAIN_SHORT_TIMEOUT));
+ }
+@@ -751,6 +971,10 @@ static void __stop_handshake(struct tb_xdomain *xd)
+ 
+ static void stop_handshake(struct tb_xdomain *xd)
+ {
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain stop handshake route=%llx state=%s local=%pUb remote=%pUb\n",
++			 xd->route, state_names[xd->state], xd->local_uuid,
++			 xd->remote_uuid);
+ 	cancel_delayed_work_sync(&xd->state_work);
+ 	__stop_handshake(xd);
+ }
+@@ -789,6 +1013,20 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 	if (xd)
+ 		update_property_block(xd);
+ 
++	if (xdomain_debug) {
++		if (xd) {
++			dev_info(&xd->dev, "XDomain dispatch request type=%s(%#x) packet_route=%llx xd_route=%llx state=%s seq=%u xdp_len=%u local=%pUb remote=%pUb\n",
++				 tb_xdp_type_name(pkg->type), pkg->type, route,
++				 xd->route, state_names[xd->state], sequence,
++				 tb_xdp_length(pkg), xd->local_uuid,
++				 xd->remote_uuid);
++		} else {
++			pr_info("thunderbolt xdomain: dispatch request with no route match type=%s(%#x) packet_route=%llx seq=%u xdp_len=%u local=%pUb\n",
++				tb_xdp_type_name(pkg->type), pkg->type, route,
++				sequence, tb_xdp_length(pkg), uuid);
++		}
++	}
++
+ 	switch (pkg->type) {
+ 	case PROPERTIES_REQUEST:
+ 		tb_dbg(tb, "%llx: received XDomain properties request\n", route);
+@@ -1354,10 +1592,17 @@ static int tb_xdomain_get_uuid(struct tb_xdomain *xd)
+ 	int ret;
+ 
+ 	dev_dbg(&xd->dev, "requesting remote UUID\n");
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain state UUID route=%llx retries=%d local=%pUb current_remote=%pUb\n",
++			 xd->route, xd->state_retries, xd->local_uuid,
++			 xd->remote_uuid);
+ 
+ 	ret = tb_xdp_uuid_request(tb->ctl, xd->route, xd->state_retries, &uuid,
+ 				  &route);
+ 	if (ret < 0) {
++		if (xdomain_debug)
++			dev_info(&xd->dev, "XDomain UUID request failed route=%llx ret=%d retries_left=%d\n",
++				 xd->route, ret, xd->state_retries);
+ 		if (xd->state_retries-- > 0) {
+ 			dev_dbg(&xd->dev, "failed to request UUID, retrying\n");
+ 			return -EAGAIN;
+@@ -1367,6 +1612,10 @@ static int tb_xdomain_get_uuid(struct tb_xdomain *xd)
+ 	}
+ 
+ 	dev_dbg(&xd->dev, "got remote UUID %pUb\n", &uuid);
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain UUID result route=%llx remote_route=%llx uuid=%pUb local=%pUb previous_remote=%pUb\n",
++			 xd->route, route, &uuid, xd->local_uuid,
++			 xd->remote_uuid);
+ 
+ 	if (uuid_equal(&uuid, xd->local_uuid)) {
+ 		if (route == xd->route)
+@@ -1543,11 +1792,19 @@ static int tb_xdomain_get_properties(struct tb_xdomain *xd)
+ 	int ret;
+ 
+ 	dev_dbg(&xd->dev, "requesting remote properties\n");
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain state PROPERTIES route=%llx retries=%d local=%pUb remote=%pUb\n",
++			 xd->route, xd->state_retries, xd->local_uuid,
++			 xd->remote_uuid);
+ 
+ 	ret = tb_xdp_properties_request(tb->ctl, xd->route, xd->local_uuid,
+ 					xd->remote_uuid, xd->state_retries,
+ 					&block, &gen);
+ 	if (ret < 0) {
++		if (xdomain_debug)
++			dev_info(&xd->dev, "XDomain properties request failed route=%llx ret=%d retries_left=%d remote=%pUb\n",
++				 xd->route, ret, xd->state_retries,
++				 xd->remote_uuid);
+ 		if (xd->state_retries-- > 0) {
+ 			dev_dbg(&xd->dev,
+ 				"failed to request remote properties, retrying\n");
+@@ -1559,6 +1816,9 @@ static int tb_xdomain_get_properties(struct tb_xdomain *xd)
+ 
+ 		return ret;
+ 	}
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain properties result route=%llx block_len=%d gen=%u remote=%pUb\n",
++			 xd->route, ret, gen, xd->remote_uuid);
+ 
+ 	mutex_lock(&xd->lock);
+ 
+@@ -2171,6 +2431,11 @@ struct tb_xdomain *tb_xdomain_alloc(struct tb *tb, struct device *parent,
+ 	dev_dbg(&xd->dev, "local UUID %pUb\n", local_uuid);
+ 	if (remote_uuid)
+ 		dev_dbg(&xd->dev, "remote UUID %pUb\n", remote_uuid);
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain allocated route=%llx parent=%s local=%pUb remote=%pUb needs_uuid=%d max_hopid=%u\n",
++			 route, dev_name(parent), xd->local_uuid,
++			 xd->remote_uuid, xd->needs_uuid,
++			 xd->local_max_hopid);
+ 
+ 	/*
+ 	 * This keeps the DMA powered on as long as we have active
+@@ -2201,6 +2466,11 @@ struct tb_xdomain *tb_xdomain_alloc(struct tb *tb, struct device *parent,
+  */
+ void tb_xdomain_add(struct tb_xdomain *xd)
+ {
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain add route=%llx link=%u depth=%u local=%pUb remote=%pUb needs_uuid=%d\n",
++			 xd->route, xd->link, xd->depth, xd->local_uuid,
++			 xd->remote_uuid, xd->needs_uuid);
++
+ 	/* Start exchanging properties with the other host */
+ 	start_handshake(xd);
+ }
+@@ -2223,6 +2493,12 @@ static int unregister_service(struct device *dev, void *data)
+  */
+ void tb_xdomain_remove(struct tb_xdomain *xd)
+ {
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain remove route=%llx link=%u depth=%u state=%s local=%pUb remote=%pUb registered=%d unplugged=%d\n",
++			 xd->route, xd->link, xd->depth, state_names[xd->state],
++			 xd->local_uuid, xd->remote_uuid,
++			 device_is_registered(&xd->dev), xd->is_unplugged);
++
+ 	tb_xdomain_debugfs_remove(xd);
+ 
+ 	mutex_lock(&xd->lock);
+@@ -2258,6 +2534,11 @@ void tb_xdomain_unregister(struct tb_xdomain *xd)
+ {
+ 	lockdep_assert_not_held(&xd->tb->lock);
+ 
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain unregister route=%llx link=%u depth=%u state=%s local=%pUb remote=%pUb\n",
++			 xd->route, xd->link, xd->depth, state_names[xd->state],
++			 xd->local_uuid, xd->remote_uuid);
++
+ 	device_for_each_child_reverse(&xd->dev, xd, unregister_service);
+ 
+ 	dev_info(&xd->dev, "host disconnected\n");
+-- 
+2.54.0
+

--- a/kernel-workflow/patches/0122-thunderbolt-xdomain-property-fixes.patch
+++ b/kernel-workflow/patches/0122-thunderbolt-xdomain-property-fixes.patch
@@ -1,0 +1,223 @@
+From e0abb380927d767d76163c942deee323935e883c Mon Sep 17 00:00:00 2001
+From: georgewhewell <georgerw@gmail.com>
+Date: Sat, 6 Jun 2026 15:30:17 +0200
+Subject: [PATCH] thunderbolt: backport XDomain property hardening fixes
+
+Backport the accepted Westeri fixes onto the thunderbolt-ibverbs portable patch base after the USB4STREAM/property-merge local stack:
+
+  01deda015206 thunderbolt: property: Reject u32 wrap in tb_property_entry_valid()
+
+  de21b59c29e3 thunderbolt: property: Reject dir_len < 4 to prevent size_t underflow
+
+  928abe19fbf0 thunderbolt: property: Cap recursion depth in __tb_property_parse_dir()
+
+  cff8eb65d1ea thunderbolt: Reject zero-length property entries in validator
+
+  65423079c742 thunderbolt: Bound root directory content to block size
+
+  322e93448d90 thunderbolt: Clamp XDomain response data copy to allocation size
+
+  a504b9f2797b thunderbolt: Validate XDomain request packet size before type cast
+
+  4db2bd2ed478 thunderbolt: Limit XDomain response copy to actual frame size
+
+These fixes are carried as one rebased patch because the raw maintainer-tree mbox conflicts with the local property merge and USB4STREAM patch stack.
+---
+ drivers/thunderbolt/property.c | 38 ++++++++++++++++++++++++++--------
+ drivers/thunderbolt/xdomain.c  | 14 ++++++++++---
+ 2 files changed, 40 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/thunderbolt/property.c b/drivers/thunderbolt/property.c
+index 6b9666b61..df18a6d69 100644
+--- a/drivers/thunderbolt/property.c
++++ b/drivers/thunderbolt/property.c
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <linux/err.h>
++#include <linux/overflow.h>
+ #include <linux/slab.h>
+ #include <linux/string.h>
+ #include <linux/uuid.h>
+@@ -34,10 +35,11 @@ struct tb_property_dir_entry {
+ };
+ 
+ #define TB_PROPERTY_ROOTDIR_MAGIC	0x55584401
++#define TB_PROPERTY_MAX_DEPTH		8
+ 
+ static struct tb_property_dir *__tb_property_parse_dir(const u32 *block,
+ 	size_t block_len, unsigned int dir_offset, size_t dir_len,
+-	bool is_root);
++	bool is_root, unsigned int depth);
+ static struct tb_property *tb_property_copy(const struct tb_property *property);
+ 
+ static inline void parse_dwdata(void *dst, const void *src, size_t dwords)
+@@ -53,13 +55,18 @@ static inline void format_dwdata(void *dst, const void *src, size_t dwords)
+ static bool tb_property_entry_valid(const struct tb_property_entry *entry,
+ 				  size_t block_len)
+ {
++	u32 end;
++
+ 	switch (entry->type) {
+ 	case TB_PROPERTY_TYPE_DIRECTORY:
+ 	case TB_PROPERTY_TYPE_DATA:
+ 	case TB_PROPERTY_TYPE_TEXT:
++		if (!entry->length)
++			return false;
+ 		if (entry->length > block_len)
+ 			return false;
+-		if (entry->value + entry->length > block_len)
++		if (check_add_overflow(entry->value, entry->length, &end) ||
++		    end > block_len)
+ 			return false;
+ 		break;
+ 
+@@ -94,7 +101,8 @@ tb_property_alloc(const char *key, enum tb_property_type type)
+ }
+ 
+ static struct tb_property *tb_property_parse(const u32 *block, size_t block_len,
+-					const struct tb_property_entry *entry)
++					const struct tb_property_entry *entry,
++					unsigned int depth)
+ {
+ 	char key[TB_PROPERTY_KEY_SIZE + 1];
+ 	struct tb_property *property;
+@@ -115,7 +123,7 @@ static struct tb_property *tb_property_parse(const u32 *block, size_t block_len,
+ 	switch (property->type) {
+ 	case TB_PROPERTY_TYPE_DIRECTORY:
+ 		dir = __tb_property_parse_dir(block, block_len, entry->value,
+-					      entry->length, false);
++					      entry->length, false, depth + 1);
+ 		if (!dir) {
+ 			kfree(property);
+ 			return NULL;
+@@ -160,21 +168,35 @@ static struct tb_property *tb_property_parse(const u32 *block, size_t block_len,
+ }
+ 
+ static struct tb_property_dir *__tb_property_parse_dir(const u32 *block,
+-	size_t block_len, unsigned int dir_offset, size_t dir_len, bool is_root)
++	size_t block_len, unsigned int dir_offset, size_t dir_len, bool is_root,
++	unsigned int depth)
+ {
+ 	const struct tb_property_entry *entries;
+ 	size_t i, content_len, nentries;
+ 	unsigned int content_offset;
+ 	struct tb_property_dir *dir;
+ 
++	if (depth > TB_PROPERTY_MAX_DEPTH)
++		return NULL;
++
+ 	dir = kzalloc_obj(*dir);
+ 	if (!dir)
+ 		return NULL;
+ 
++	INIT_LIST_HEAD(&dir->properties);
++
+ 	if (is_root) {
+ 		content_offset = dir_offset + 2;
+ 		content_len = dir_len;
++		if (content_offset + content_len > block_len) {
++			tb_property_free_dir(dir);
++			return NULL;
++		}
+ 	} else {
++		if (dir_len < 4) {
++			tb_property_free_dir(dir);
++			return NULL;
++		}
+ 		dir->uuid = kmemdup(&block[dir_offset], sizeof(*dir->uuid),
+ 				    GFP_KERNEL);
+ 		if (!dir->uuid) {
+@@ -188,12 +210,10 @@ static struct tb_property_dir *__tb_property_parse_dir(const u32 *block,
+ 	entries = (const struct tb_property_entry *)&block[content_offset];
+ 	nentries = content_len / (sizeof(*entries) / 4);
+ 
+-	INIT_LIST_HEAD(&dir->properties);
+-
+ 	for (i = 0; i < nentries; i++) {
+ 		struct tb_property *property;
+ 
+-		property = tb_property_parse(block, block_len, &entries[i]);
++		property = tb_property_parse(block, block_len, &entries[i], depth);
+ 		if (!property) {
+ 			tb_property_free_dir(dir);
+ 			return NULL;
+@@ -232,7 +252,7 @@ struct tb_property_dir *tb_property_parse_dir(const u32 *block,
+ 		return NULL;
+ 
+ 	return __tb_property_parse_dir(block, block_len, 0, rootdir->length,
+-				       true);
++				       true, 0);
+ }
+ 
+ /**
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+index d45f03207..395c7cd12 100644
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -55,6 +55,7 @@ static const char * const state_names[] = {
+ struct xdomain_request_work {
+ 	struct work_struct work;
+ 	struct tb_xdp_header *pkg;
++	size_t pkg_len;
+ 	struct tb *tb;
+ };
+ 
+@@ -122,7 +123,9 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ static bool tb_xdomain_copy(struct tb_cfg_request *req,
+ 			    const struct ctl_pkg *pkg)
+ {
+-	memcpy(req->response, pkg->buffer, req->response_size);
++	size_t len = min_t(size_t, pkg->frame.size, req->response_size);
++
++	memcpy(req->response, pkg->buffer, len);
+ 	req->result.err = 0;
+ 	return true;
+ }
+@@ -398,6 +401,8 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 			}
+ 		}
+ 
++		if (req.offset + len > data_len)
++			len = data_len - req.offset;
+ 		memcpy(data + req.offset, res->data, len * 4);
+ 		req.offset += len;
+ 	} while (!data_len || req.offset < data_len);
+@@ -755,6 +760,7 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 	struct xdomain_request_work *xw = container_of(work, typeof(*xw), work);
+ 	const struct tb_xdp_header *pkg = xw->pkg;
+ 	const struct tb_xdomain_header *xhdr = &pkg->xd_hdr;
++	size_t pkg_len = xw->pkg_len;
+ 	struct tb *tb = xw->tb;
+ 	struct tb_ctl *ctl = tb->ctl;
+ 	struct tb_xdomain *xd;
+@@ -786,7 +792,7 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 	switch (pkg->type) {
+ 	case PROPERTIES_REQUEST:
+ 		tb_dbg(tb, "%llx: received XDomain properties request\n", route);
+-		if (xd) {
++		if (xd && pkg_len >= sizeof(struct tb_xdp_properties)) {
+ 			ret = tb_xdp_properties_response(tb, ctl, xd, sequence,
+ 				(const struct tb_xdp_properties *)pkg);
+ 		}
+@@ -879,7 +885,8 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 		tb_dbg(tb, "%llx: received XDomain link state change request\n",
+ 		       route);
+ 
+-		if (xd && xd->state == XDOMAIN_STATE_BONDING_UUID_HIGH) {
++		if (xd && xd->state == XDOMAIN_STATE_BONDING_UUID_HIGH &&
++		    pkg_len >= sizeof(struct tb_xdp_link_state_change)) {
+ 			const struct tb_xdp_link_state_change *lsc =
+ 				(const struct tb_xdp_link_state_change *)pkg;
+ 
+@@ -932,6 +939,7 @@ tb_xdp_schedule_request(struct tb *tb, const struct tb_xdp_header *hdr,
+ 		kfree(xw);
+ 		return false;
+ 	}
++	xw->pkg_len = size;
+ 	xw->tb = tb_domain_get(tb);
+ 
+ 	schedule_work(&xw->work);
+-- 
+2.54.0
+

--- a/kernel-workflow/patches/0123-thunderbolt-Prevent-XDomain-delayed-work-use-after.patch
+++ b/kernel-workflow/patches/0123-thunderbolt-Prevent-XDomain-delayed-work-use-after.patch
@@ -1,0 +1,145 @@
+From 2c5d2d3c3f70cde2565d7b279b544893a2035842 Mon Sep 17 00:00:00 2001
+From: Michael Bommarito <michael.bommarito@gmail.com>
+Date: Wed, 27 May 2026 07:46:04 -0400
+Subject: [PATCH] thunderbolt: Prevent XDomain delayed work use-after-free on
+ disconnect
+
+tb_xdp_handle_request() runs on system_wq and queues
+xd->state_work via queue_delayed_work() in three request handlers:
+PROPERTIES_CHANGED_REQUEST, UUID_REQUEST (via start_handshake),
+and LINK_STATE_CHANGE_REQUEST.  Similarly, update_xdomain() queues
+xd->properties_changed_work when local properties change.
+
+Concurrently, tb_xdomain_remove() calls stop_handshake() which does
+cancel_delayed_work_sync() on both delayed works.  Later,
+tb_xdomain_unregister() calls device_unregister() which eventually
+frees the xdomain.  Since commit 559c1e1e0134 ("thunderbolt: Run
+tb_xdp_handle_request() in system workqueue") moved the request
+handler off tb->wq, the handler and the remove path are no longer
+serialized.  If queue_delayed_work() executes after
+cancel_delayed_work_sync() but before the xdomain is freed, the
+delayed work fires on a freed object.
+
+Add xd->removing that tb_xdomain_remove() sets under xd->lock
+before calling stop_handshake().  Each external queue site holds
+the same lock and checks removing before calling
+queue_delayed_work().  This provides the mutual exclusion needed:
+either the queue site acquires the lock first and queues work that
+the subsequent cancel will see, or the remove path acquires the
+lock first and the queue site observes removing == true and skips
+the queue.
+
+Fixes: 559c1e1e0134 ("thunderbolt: Run tb_xdp_handle_request() in system workqueue")
+Cc: stable@vger.kernel.org
+Assisted-by: Claude:claude-opus-4-7
+Signed-off-by: Michael Bommarito <michael.bommarito@gmail.com>
+Signed-off-by: Mika Westerberg <mika.westerberg@linux.intel.com>
+---
+ drivers/thunderbolt/xdomain.c | 41 ++++++++++++++++++++++++++---------
+ include/linux/thunderbolt.h   |  3 +++
+ 2 files changed, 34 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+index 781d88d06b93..fe6c5ac703f4 100644
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -803,9 +803,13 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 		 * the xdomain related to this connection as well in
+ 		 * case there is a change in services it offers.
+ 		 */
+-		if (xd && device_is_registered(&xd->dev))
+-			queue_delayed_work(tb->wq, &xd->state_work,
+-					   msecs_to_jiffies(XDOMAIN_SHORT_TIMEOUT));
++		if (xd) {
++			mutex_lock(&xd->lock);
++			if (!xd->removing && device_is_registered(&xd->dev))
++				queue_delayed_work(tb->wq, &xd->state_work,
++						   msecs_to_jiffies(XDOMAIN_SHORT_TIMEOUT));
++			mutex_unlock(&xd->lock);
++		}
+ 		break;
+ 
+ 	case UUID_REQUEST_OLD:
+@@ -818,8 +822,12 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 		 * received UUID request from the remote host.
+ 		 */
+ 		if (!ret && xd && xd->state == XDOMAIN_STATE_ERROR) {
+-			dev_dbg(&xd->dev, "restarting handshake\n");
+-			start_handshake(xd);
++			mutex_lock(&xd->lock);
++			if (!xd->removing) {
++				dev_dbg(&xd->dev, "restarting handshake\n");
++				start_handshake(xd);
++			}
++			mutex_unlock(&xd->lock);
+ 		}
+ 		break;
+ 
+@@ -885,9 +893,13 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 
+ 			ret = tb_xdp_link_state_change_response(ctl, route,
+ 								sequence, 0);
+-			xd->target_link_width = lsc->tlw;
+-			queue_delayed_work(tb->wq, &xd->state_work,
+-					   msecs_to_jiffies(XDOMAIN_SHORT_TIMEOUT));
++			mutex_lock(&xd->lock);
++			if (!xd->removing) {
++				xd->target_link_width = lsc->tlw;
++				queue_delayed_work(tb->wq, &xd->state_work,
++						   msecs_to_jiffies(XDOMAIN_SHORT_TIMEOUT));
++			}
++			mutex_unlock(&xd->lock);
+ 		} else {
+ 			tb_xdp_error_response(ctl, route, sequence,
+ 					      ERROR_NOT_READY);
+@@ -971,8 +983,12 @@ static int update_xdomain(struct device *dev, void *data)
+ 
+ 	xd = tb_to_xdomain(dev);
+ 	if (xd) {
+-		queue_delayed_work(xd->tb->wq, &xd->properties_changed_work,
+-				   msecs_to_jiffies(50));
++		mutex_lock(&xd->lock);
++		if (!xd->removing)
++			queue_delayed_work(xd->tb->wq,
++					   &xd->properties_changed_work,
++					   msecs_to_jiffies(50));
++		mutex_unlock(&xd->lock);
+ 	}
+ 
+ 	return 0;
+@@ -2200,6 +2216,11 @@ static int unregister_service(struct device *dev, void *data)
+ void tb_xdomain_remove(struct tb_xdomain *xd)
+ {
+ 	tb_xdomain_debugfs_remove(xd);
++
++	mutex_lock(&xd->lock);
++	xd->removing = true;
++	mutex_unlock(&xd->lock);
++
+ 	stop_handshake(xd);
+ 	tb_xdomain_link_exit(xd);
+ 
+diff --git a/include/linux/thunderbolt.h b/include/linux/thunderbolt.h
+index b5659f883517..feb1af175cfd 100644
+--- a/include/linux/thunderbolt.h
++++ b/include/linux/thunderbolt.h
+@@ -213,6 +213,8 @@ enum tb_link_width {
+  * @link_width: Width of the downstream facing link
+  * @link_usb4: Downstream link is USB4
+  * @is_unplugged: The XDomain is unplugged
++ * @removing: Set by tb_xdomain_remove() under @lock to prevent
++ *	      concurrent delayed work queueing
+  * @needs_uuid: If the XDomain does not have @remote_uuid it will be
+  *		queried first
+  * @service_ids: Used to generate IDs for the services
+@@ -262,6 +264,7 @@ struct tb_xdomain {
+ 	enum tb_link_width link_width;
+ 	bool link_usb4;
+ 	bool is_unplugged;
++	bool removing;
+ 	bool needs_uuid;
+ 	struct ida service_ids;
+ 	struct ida in_hopids;
+-- 
+2.54.0
+

--- a/kernel-workflow/patches/local-portable.nix
+++ b/kernel-workflow/patches/local-portable.nix
@@ -2,3 +2,21 @@ let
   debugNames = map (patch: patch.name) (import ./local-integration-debug.nix);
 in
 builtins.filter (patch: !(builtins.elem patch.name debugNames)) (import ./local.nix)
+++ [
+  {
+    name = "usb4-xdomain-property-fixes";
+    patch = ./0122-thunderbolt-xdomain-property-fixes.patch;
+  }
+  {
+    name = "usb4-xdomain-delayed-work-uaf";
+    patch = ./0123-thunderbolt-Prevent-XDomain-delayed-work-use-after.patch;
+  }
+  {
+    name = "usb4-xdomain-lane-bonding-module-param";
+    patch = ./0009-thunderbolt-xdomain-lane-bonding-module-param.patch;
+  }
+  {
+    name = "usb4-xdomain-route-trace";
+    patch = ./0010-thunderbolt-trace-XDomain-route-matching.patch;
+  }
+]


### PR DESCRIPTION
## Summary

- add the current XDomain property/frame hardening fixes to the exported portable kernel patch stack
- add the XDomain delayed-work disconnect UAF fix
- move the lane-bonding debug module parameter and XDomain route tracing patches into thunderbolt-ibverbs
- keep downstream NixOS configs from needing to carry duplicate local Thunderbolt patches

The property hardening patch is a rebased backport over the current USB4STREAM/property-merge portable base. The raw Westeri fixes mbox conflicts with that local stack, so this PR carries the same accepted fixes as one rebased patch.

## Validation

- `nix build .#checks.x86_64-linux.portable-kernel-patches --no-link`
