### PR TITLE
bench: support Apple RDMA perftest workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ nix build github:hellas-ai/thunderbolt-ibverbs#bench-tools      # u4_pingpong, u
 `nix develop` drops you in a shell with the module headers, `rdma-core-usb4`,
 `perftest`, and the bench tools on PATH.
 
+For benchmark hosts that need SSH aliases or a jump host, pass an SSH config to
+the generated runner:
+
+```sh
+nix run .#tbv-perftest -- \
+  --ssh-config /tmp/tbv_ssh_config \
+  --hosts goblin,mbp-tb \
+  --data-addrs goblin=192.168.0.1,mbp-tb=192.168.0.2
+```
+
 On NixOS, add the flake input and import the module:
 
 ```nix

--- a/bench/README.md
+++ b/bench/README.md
@@ -94,4 +94,50 @@ nix run .#tbv-perftest -- --hosts strix-1,strix-2 \
   --tag rxe-tbnet --csv "$out/rxe-tbnet.csv" --jsonl "$out/rxe-tbnet.jsonl"
 ```
 
+## Apple Thunderbolt RDMA
+
+Apple `rdma_en*` devices need the Thunderbolt interface, not `bridge0`, to own
+the per-port test IP. Use MLX's configurator or equivalent `ifconfig` setup
+before running perftest; this creates the IPv4-mapped GID at index 1 that
+JACCL and Apple's provider expect.
+
+```sh
+# Run from the first Mac. Use LAN/Wi-Fi/Ethernet SSH names here, not the
+# Thunderbolt data addresses.
+mlx.distributed_config \
+  --hosts localhost,<peer-lan-host-or-ip> \
+  --over thunderbolt \
+  --backend jaccl \
+  --auto-setup \
+  --output-hostfile /tmp/mlx_hosts_auto.json
+```
+
+When SSH and RDMA use different addresses, tell `tbv-perftest` both. The
+runner still SSHs `--server` / `--client`, but passes `--*-data-addr` to the
+perftest client so address exchange selects the Thunderbolt GID.
+
+```sh
+# Example: goblin rdma_en2 at 192.168.0.1, mbp rdma_en3 at 192.168.0.2.
+nix run .#tbv-perftest -- \
+  --server goblin \
+  --client 192.168.23.240 \
+  --server-dev rdma_en2 \
+  --client-dev rdma_en3 \
+  --server-data-addr 192.168.0.1 \
+  --client-data-addr 192.168.0.2 \
+  --only 'bw.uc.ib_send_bw.size65536.qps1' \
+  --only 'lat.uc.ib_send_lat.size4096' \
+  --directions both \
+  --no-rail-check \
+  --tag apple-uc-smoke \
+  --csv "$out/apple-uc-smoke.csv" \
+  --jsonl "$out/apple-uc-smoke.jsonl"
+```
+
+For `rdma_en*` UC cases the runner defaults to `--gid-index 1`, `--mtu 1024`,
+and caps UC SEND queue depths at 32. These defaults match the working JACCL
+shape. UC SEND is the reliable Apple smoke path; UC WRITE cases are still useful
+for investigation but can hang or report misleading bandwidth depending on the
+peer implementation.
+
 Historical checked-in result sets live under `bench/results/`.

--- a/userspace/bench/tbv_perftest_runner.py
+++ b/userspace/bench/tbv_perftest_runner.py
@@ -282,6 +282,8 @@ PERFTEST_DARWIN = os.environ.get("TBV_PERFTEST_DARWIN", "")
 
 # Set once per run by detect_systems(); maps hostname -> "Linux" / "Darwin".
 HOST_SYSTEM: dict[str, str] = {}
+SSH_CONFIG = ""
+SSH_OPTIONS: list[str] = []
 
 
 def perftest_for(host: str) -> str:
@@ -294,15 +296,24 @@ def rdma_core_for(host: str) -> str:
 
 
 def ssh_args(target: str, command: str) -> list[str]:
-    return [
+    args = [
         "ssh",
+    ]
+    if SSH_CONFIG:
+        args.extend(["-F", SSH_CONFIG])
+    args.extend([
         "-o",
         "ConnectTimeout=8",
         "-o",
         "BatchMode=yes",
+    ])
+    for option in SSH_OPTIONS:
+        args.extend(["-o", option])
+    args.extend([
         target,
         "sudo -n bash -lc " + shlex.quote(command),
-    ]
+    ])
+    return args
 
 
 def run_local(args: list[str], *, check: bool = True, timeout: int | None = None) -> subprocess.CompletedProcess[str]:
@@ -983,6 +994,8 @@ def main() -> int:
     parser.add_argument("--server-data-addr", help="address clients should use to connect to the server host")
     parser.add_argument("--client-data-addr", help="address clients should use to connect to the client host when directions reverse")
     parser.add_argument("--data-addrs", help="comma-separated host=addr map for perftest's data connection target")
+    parser.add_argument("--ssh-config", help="ssh_config file passed to ssh with -F")
+    parser.add_argument("--ssh-option", action="append", default=[], help="extra ssh -o option; may be repeated")
     parser.add_argument("--dev")
     parser.add_argument("--server-dev", help="override --dev on the server side (asymmetric pairs)")
     parser.add_argument("--client-dev", help="override --dev on the client side (asymmetric pairs)")
@@ -1012,6 +1025,9 @@ def main() -> int:
     args = parser.parse_args()
     if args.repeat < 1:
         die("--repeat must be >= 1")
+    global SSH_CONFIG, SSH_OPTIONS
+    SSH_CONFIG = args.ssh_config or os.environ.get("TBV_SSH_CONFIG", "")
+    SSH_OPTIONS = list(args.ssh_option or [])
 
     plan = json.loads(Path(args.plan).read_text())
     defaults = dict(plan.get("defaults", {}))

--- a/userspace/bench/tbv_perftest_runner.py
+++ b/userspace/bench/tbv_perftest_runner.py
@@ -191,6 +191,11 @@ FATAL_COUNTERS = [
     "data_cq_overflow",
 ]
 
+APPLE_RDMA_DEV_PREFIX = "rdma_en"
+APPLE_UC_GID_INDEX = 1
+APPLE_UC_MTU = 1024
+APPLE_UC_QUEUE_DEPTH = 32
+
 CSV_FIELDS = [
     "timestamp_utc",
     "plan",
@@ -210,6 +215,10 @@ CSV_FIELDS = [
     "iommu",
     "direction",
     "dev",
+    "server_dev",
+    "client_dev",
+    "server_data_addr",
+    "client_data_addr",
     "gid_index",
     "port",
     "status",
@@ -220,6 +229,7 @@ CSV_FIELDS = [
     "tx_depth",
     "rx_depth",
     "connection",
+    "mtu",
     "bidirectional",
     "bw_peak_gbps",
     "bw_avg_gbps",
@@ -535,6 +545,7 @@ def parse_case_options(case: dict[str, Any]) -> dict[str, str]:
         "--tx-depth": "tx_depth",
         "--rx-depth": "rx_depth",
         "--connection": "connection",
+        "--mtu": "mtu",
     }
     i = 0
     while i < len(argv):
@@ -548,6 +559,25 @@ def parse_case_options(case: dict[str, Any]) -> dict[str, str]:
         i += 1
     out.setdefault("bidirectional", "0")
     return out
+
+
+def cap_option_string(value: str | None, cap: int) -> str:
+    if value is None:
+        return str(cap)
+    try:
+        return str(min(int(value), cap))
+    except ValueError:
+        return value
+
+
+def effective_case_options(case: dict[str, Any], pair_has_apple_rdma: bool) -> dict[str, str]:
+    opts = parse_case_options(case)
+    if pair_has_apple_rdma and case_connection(case) == "UC":
+        opts.setdefault("mtu", str(APPLE_UC_MTU))
+        if perftest_verb(case) == "send":
+            opts["tx_depth"] = cap_option_string(opts.get("tx_depth"), APPLE_UC_QUEUE_DEPTH)
+            opts["rx_depth"] = cap_option_string(opts.get("rx_depth"), APPLE_UC_QUEUE_DEPTH)
+    return opts
 
 
 def strip_option(argv: list[str], flags: set[str]) -> list[str]:
@@ -569,12 +599,56 @@ def strip_option(argv: list[str], flags: set[str]) -> list[str]:
     return out
 
 
+def option_value(argv: list[str], flags: set[str]) -> str | None:
+    i = 0
+    while i < len(argv):
+        item = argv[i]
+        if item in flags and i + 1 < len(argv):
+            return argv[i + 1]
+        for flag in flags:
+            prefix = flag + "="
+            if item.startswith(prefix):
+                return item[len(prefix):]
+        i += 1
+    return None
+
+
+def append_default_option(argv: list[str], flags: set[str], flag: str, value: int) -> None:
+    if option_value(argv, flags) is None:
+        argv.extend([flag, str(value)])
+
+
+def cap_int_option(argv: list[str], flags: set[str], flag: str, value: int) -> list[str]:
+    current = option_value(argv, flags)
+    if current is None:
+        argv.extend([flag, str(value)])
+        return argv
+    try:
+        capped = min(int(current), value)
+    except ValueError:
+        return argv
+    argv = strip_option(argv, flags)
+    argv.extend([flag, str(capped)])
+    return argv
+
+
+def case_connection(case: dict[str, Any]) -> str:
+    argv = [str(x) for x in case.get("argv", [])]
+    return (option_value(argv, {"--connection", "-c"}) or "RC").upper()
+
+
+def is_apple_rdma_dev(dev: str) -> bool:
+    return dev.startswith(APPLE_RDMA_DEV_PREFIX)
+
+
 def build_perftest_command(
     case: dict[str, Any],
     *,
     perftest_path: str,
     rdma_lib: str,
     pair_has_darwin: bool,
+    pair_has_apple_rdma: bool,
+    host_is_darwin: bool,
     dev: str,
     gid_index: int,
     port: int,
@@ -586,6 +660,11 @@ def build_perftest_command(
         [str(x) for x in case.get("argv", [])],
         {"--ib-dev", "-d", "--gid-index", "-x", "--port", "-p", "--out_json_file"},
     )
+    if pair_has_apple_rdma and case_connection(case) == "UC":
+        append_default_option(argv, {"--mtu", "-m"}, "--mtu", APPLE_UC_MTU)
+        if perftest_verb(case) == "send":
+            argv = cap_int_option(argv, {"--tx-depth", "-t"}, "--tx-depth", APPLE_UC_QUEUE_DEPTH)
+            argv = cap_int_option(argv, {"--rx-depth", "-r"}, "--rx-depth", APPLE_UC_QUEUE_DEPTH)
     argv.extend(["--ib-dev", dev, "--gid-index", str(gid_index), "--port", str(port), "-F"])
     if pair_has_darwin and "--use_old_post_send" not in argv:
         # Apple perftest is built with --disable-ibv_wr_api; force both sides
@@ -602,12 +681,13 @@ def build_perftest_command(
     bin_path = f"{perftest_path}/bin/{case['bin']}"
     quoted = " ".join(shlex.quote(str(arg)) for arg in argv)
     lib_prefix = f"LD_LIBRARY_PATH={shlex.quote(rdma_lib + '/lib')} " if rdma_lib else ""
+    timeout_prefix = "" if host_is_darwin else f"timeout {shlex.quote(str(timeout))} "
     return (
         "set -euo pipefail; "
         f"mkdir -p {shlex.quote(str(Path(remote_json).parent))}; "
         f"cd {shlex.quote(str(Path(remote_json).parent))}; "
         f"{lib_prefix}"
-        f"timeout {shlex.quote(str(timeout))} {shlex.quote(bin_path)} {quoted}"
+        f"{timeout_prefix}{shlex.quote(bin_path)} {quoted}"
     )
 
 
@@ -702,6 +782,7 @@ def run_pair(
     client_rdma_lib: str,
     server_dev: str,
     client_dev: str,
+    peer_addr: str,
     gid_index: int,
     port: int,
     timeout: int,
@@ -710,12 +791,17 @@ def run_pair(
     remote_dir = f"/tmp/tbv-perftest/{run_id}"
     server_json = f"{remote_dir}/server.json"
     client_json = f"{remote_dir}/client.json"
-    pair_has_darwin = "Darwin" in (HOST_SYSTEM.get(server), HOST_SYSTEM.get(client))
+    server_is_darwin = HOST_SYSTEM.get(server) == "Darwin"
+    client_is_darwin = HOST_SYSTEM.get(client) == "Darwin"
+    pair_has_darwin = server_is_darwin or client_is_darwin
+    pair_has_apple_rdma = is_apple_rdma_dev(server_dev) or is_apple_rdma_dev(client_dev)
     server_cmd = build_perftest_command(
         case,
         perftest_path=server_perftest,
         rdma_lib=server_rdma_lib,
         pair_has_darwin=pair_has_darwin,
+        pair_has_apple_rdma=pair_has_apple_rdma,
+        host_is_darwin=server_is_darwin,
         dev=server_dev,
         gid_index=gid_index,
         port=port,
@@ -728,12 +814,14 @@ def run_pair(
         perftest_path=client_perftest,
         rdma_lib=client_rdma_lib,
         pair_has_darwin=pair_has_darwin,
+        pair_has_apple_rdma=pair_has_apple_rdma,
+        host_is_darwin=client_is_darwin,
         dev=client_dev,
         gid_index=gid_index,
         port=port,
         timeout=timeout,
         remote_json=client_json,
-        peer=server,
+        peer=peer_addr,
     )
 
     server_proc = subprocess.Popen(
@@ -743,11 +831,33 @@ def run_pair(
         text=True,
     )
     time.sleep(server_start_delay)
-    client_proc = run_ssh(client, client_cmd, check=False, timeout=timeout + 20)
+    try:
+        client_proc = run_ssh(client, client_cmd, check=False, timeout=timeout + 20)
+    except subprocess.TimeoutExpired as exc:
+        cleanup_remote_run(server, remote_dir)
+        cleanup_remote_run(client, remote_dir)
+        server_proc.terminate()
+        try:
+            server_stdout, _ = server_proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            server_proc.kill()
+            server_stdout, _ = server_proc.communicate()
+        stdout = exc.stdout or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        return "fail", {}, f"client ssh timeout: {str(stdout).strip()[-800:]}", {
+            "server_stdout": server_stdout,
+            "client_stdout": stdout,
+            "server_returncode": server_proc.returncode,
+            "client_returncode": None,
+            "server_json": load_remote_json(server, server_json),
+            "client_json": load_remote_json(client, client_json),
+        }
     server_reap_error = ""
     try:
         server_stdout, _ = server_proc.communicate(timeout=15)
     except subprocess.TimeoutExpired:
+        cleanup_remote_run(server, remote_dir)
         server_proc.terminate()
         try:
             server_stdout, _ = server_proc.communicate(timeout=5)
@@ -850,12 +960,29 @@ def parse_hosts(value: str) -> tuple[str, str]:
     return parts[0], parts[1]
 
 
+def parse_host_map(value: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not value:
+        return out
+    for part in re.split(r"[, ]+", value):
+        if not part:
+            continue
+        host, sep, addr = part.partition("=")
+        if not sep or not host or not addr:
+            die("--data-addrs entries must look like host=addr")
+        out[host] = addr
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run a Nix-generated perftest benchmark plan.")
     parser.add_argument("--plan", required=True)
     parser.add_argument("--server")
     parser.add_argument("--client")
     parser.add_argument("--hosts", help="Shortcut for --server A --client B")
+    parser.add_argument("--server-data-addr", help="address clients should use to connect to the server host")
+    parser.add_argument("--client-data-addr", help="address clients should use to connect to the client host when directions reverse")
+    parser.add_argument("--data-addrs", help="comma-separated host=addr map for perftest's data connection target")
     parser.add_argument("--dev")
     parser.add_argument("--server-dev", help="override --dev on the server side (asymmetric pairs)")
     parser.add_argument("--client-dev", help="override --dev on the client side (asymmetric pairs)")
@@ -900,7 +1027,18 @@ def main() -> int:
         server: args.server_dev or dev,
         client: args.client_dev or dev,
     }
-    gid_index = args.gid_index if args.gid_index is not None else int(defaults["gidIndex"])
+    host_data_addr = {
+        server: args.server_data_addr or server,
+        client: args.client_data_addr or client,
+    }
+    host_data_addr.update(parse_host_map(args.data_addrs or ""))
+    pair_has_apple_rdma = is_apple_rdma_dev(host_dev[server]) or is_apple_rdma_dev(host_dev[client])
+    if args.gid_index is not None:
+        gid_index = args.gid_index
+    elif pair_has_apple_rdma:
+        gid_index = APPLE_UC_GID_INDEX
+    else:
+        gid_index = int(defaults["gidIndex"])
     backend = args.backend if args.backend is not None else defaults.get("backend")
     netdev = args.netdev or defaults.get("netdev")
     if args.no_rail_check:
@@ -1002,7 +1140,7 @@ def main() -> int:
                         assert_topology(run_server, before_server, expect_rails, expect_speed)
                         assert_topology(run_client, before_client, expect_rails, expect_speed)
 
-                        opts = parse_case_options(case)
+                        opts = effective_case_options(case, pair_has_apple_rdma)
                         row: dict[str, Any] = {
                             "timestamp_utc": now_utc(),
                             "plan": plan["name"],
@@ -1021,7 +1159,15 @@ def main() -> int:
                             "module_ko_path": identity_server.get("ko_path", ""),
                             "iommu": identity_server.get("iommu", ""),
                             "direction": direction_name,
-                            "dev": dev,
+                            "dev": (
+                                host_dev[run_server]
+                                if host_dev[run_server] == host_dev[run_client]
+                                else f"{host_dev[run_server]}->{host_dev[run_client]}"
+                            ),
+                            "server_dev": host_dev[run_server],
+                            "client_dev": host_dev[run_client],
+                            "server_data_addr": host_data_addr.get(run_server, run_server),
+                            "client_data_addr": host_data_addr.get(run_client, run_client),
                             "gid_index": str(gid_index),
                             "port": str(port),
                             "status": "",
@@ -1043,6 +1189,7 @@ def main() -> int:
                             client_rdma_lib=rdma_core_for(run_client),
                             server_dev=host_dev[run_server],
                             client_dev=host_dev[run_client],
+                            peer_addr=host_data_addr.get(run_server, run_server),
                             gid_index=gid_index,
                             port=port,
                             timeout=timeout,


### PR DESCRIPTION
## Summary
- add separate perftest data-address overrides for cases where SSH and RDMA traffic use different paths
- allow the generated `tbv-perftest` runner to use an explicit SSH config / repeated SSH `-o` options for jump-host lab topologies
- default Apple rdma_en* UC runs to GID index 1 and MTU 1024
- cap Apple UC SEND queue depths to 32 and avoid GNU timeout on Darwin remotes
- record per-host devices/data addresses in CSV output for asymmetric runs
- document the Apple/MLX per-port Thunderbolt setup and SSH-config benchmark flow in the README

## Tested
- `nix shell nixpkgs#python3 -c python3 -m py_compile userspace/bench/tbv_perftest_runner.py`
- `/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/bin/python3 -m py_compile userspace/bench/tbv_perftest_runner.py`
- `git diff --check`
- `nix build .#tbv-perftest -L`
- `nix flake check --no-build`
- MLX/JACCL smoke via `/tmp/mlx_hosts_auto.json`: ok, both ranks report all-sum `[2.0, ...]`
- goblin `rdma_en2` <-> MBP `rdma_en3`, Apple/MLX per-port setup (`192.168.0.1/30`, `192.168.0.2/30`)
- forward `bw.uc.ib_send_bw.size65536.qps1`: ok, avg `75.00 Gbit/s`, peak `75.13 Gbit/s`
- reverse `bw.uc.ib_send_bw.size65536.qps1`: ok, avg `68.93 Gbit/s`, peak `73.73 Gbit/s`
- forward `lat.uc.ib_send_lat.size4096`: ok, avg `4.64 us`, p99 `5.96 us`
- reverse `lat.uc.ib_send_lat.size4096`: ok, avg `5.10 us`, p99 `7.07 us`
- repeat mac->mac smoke through `--ssh-config /tmp/tbv_ssh_config` and ProxyJump via goblin: `lat.uc.ib_send_lat.size4096` ok, avg `4.20 us`, p99 `5.25 us`
- repeat mac<->mac smoke through the same runner path: forward SEND BW `75.12 Gbit/s`, reverse SEND BW `65.61 Gbit/s`; forward latency avg `5.02 us` p99 `8.48 us`, reverse latency avg `4.94 us` p99 `7.93 us`

All perftest rows used effective Apple params: `gid-index=1`, `mtu=1024`, `tx-depth=32`, `rx-depth=32`.
