### PR TITLE
apple: wait for TBnet neighbor before FA57 tunnels

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -38,7 +38,6 @@ help:
 	@echo "  tbnet_identity=auto|stock|stock_proxy|minimal_packet|off"
 	@echo "  tbnet_identity_tbnet=<netdev>"
 	@echo "  tbnet_identity_gid=auto|<netdev>"
-	@echo "  tbnet_identity_minimal_e2e=0|1"
 	@echo "  tbnet_identity_minimal_apple_only=0|1"
 	@echo "  bind_services=0|1"
 	@echo "  allocate_rings=0|1"

--- a/kernel/debugfs.c
+++ b/kernel/debugfs.c
@@ -51,8 +51,6 @@ static int tbv_debugfs_summary_show(struct seq_file *s, void *unused)
 		   state->tbnet_identity.gid_netdev_name : "<unset>");
 	seq_printf(s, "tbnet_identity_proxy_ipv4: %pI4\n",
 		   &state->tbnet_identity.proxy_ipv4);
-	seq_printf(s, "tbnet_identity_minimal_e2e: %u\n",
-		   state->tbnet_identity.minimal_e2e);
 	seq_printf(s, "tbnet_identity_minimal_apple_only: %u\n",
 		   state->tbnet_identity.minimal_apple_only);
 	seq_printf(s, "tbnet_identity_minimal_neighbor_seen: %u\n",

--- a/kernel/ibdev.c
+++ b/kernel/ibdev.c
@@ -3086,6 +3086,39 @@ static void tbv_apple_send_complete_work(struct work_struct *work)
 	tbv_send_ctx_put(send);
 }
 
+static void tbv_apple_complete_ordered_sends(struct tbv_qp *tqp,
+					     struct list_head *complete)
+{
+	while (!list_empty(complete)) {
+		struct tbv_send_ctx *send =
+			list_first_entry(complete, struct tbv_send_ctx, node);
+		int status = send->completion_status;
+
+		list_del_init(&send->node);
+		if (!status) {
+			u32 delay_us = READ_ONCE(apple_tx_completion_delay_us);
+
+			if (delay_us) {
+				struct workqueue_struct *wq =
+					tqp->owner && tqp->owner->workqueue ?
+						tqp->owner->workqueue :
+						system_unbound_wq;
+				unsigned long delay =
+					max_t(unsigned long, 1,
+					      usecs_to_jiffies(delay_us));
+
+				send->apple_complete_status = 0;
+				queue_delayed_work(wq, &send->apple_complete_work,
+						   delay);
+				continue;
+			}
+		}
+
+		tbv_send_complete(send, status);
+		tbv_send_ctx_put(send);
+	}
+}
+
 static bool tbv_qp_timeout_reap_tx(struct tbv_qp *tqp,
 				   struct list_head *retry_sends,
 				   struct list_head *completed_sends,
@@ -3724,33 +3757,12 @@ static void tbv_apple_send_tx_done(void *ctx, int status)
 
 	last = atomic_dec_and_test(&send->apple_pending);
 	wake_up_all(&tqp->apple_tx_wait);
-	if (status) {
-		if (tbv_qp_unqueue_send(tqp, send)) {
-			tbv_send_complete(send, status);
-			tbv_send_ctx_put(send);
-		}
-	} else if (last) {
-		if (tbv_qp_unqueue_send(tqp, send)) {
-			u32 delay_us = READ_ONCE(apple_tx_completion_delay_us);
+	if (status || last) {
+		LIST_HEAD(complete);
 
-			if (delay_us) {
-				struct workqueue_struct *wq =
-					tqp->owner && tqp->owner->workqueue ?
-						tqp->owner->workqueue :
-						system_unbound_wq;
-				unsigned long delay =
-					max_t(unsigned long, 1,
-					      usecs_to_jiffies(delay_us));
-
-				send->apple_complete_status = 0;
-				queue_delayed_work(wq,
-						   &send->apple_complete_work,
-						   delay);
-			} else {
-				tbv_send_complete(send, 0);
-				tbv_send_ctx_put(send);
-			}
-		}
+		if (tbv_qp_complete_send_ordered(tqp, send->psn, status,
+						 &complete, NULL))
+			tbv_apple_complete_ordered_sends(tqp, &complete);
 	}
 
 	tbv_send_ctx_put(send);

--- a/kernel/ibdev.c
+++ b/kernel/ibdev.c
@@ -5353,6 +5353,7 @@ void tbv_ibdev_rx_apple_frame(struct tbv_state *state,
 {
 	struct tbv_apple_pending_rx *pending;
 	struct tbv_qp *tqp;
+	bool starts_message;
 	bool raw_rx;
 	u32 qpn;
 	u32 user_len = 0;
@@ -5380,12 +5381,19 @@ void tbv_ibdev_rx_apple_frame(struct tbv_state *state,
 		return;
 	}
 
+	/*
+	 * macOS emits short single-frame SENDs as EOF=3 without SOF.  Treat
+	 * those as a complete message start, but keep rejecting idle non-final
+	 * fragments because there is no Apple-side sequence number to recover
+	 * the missing prefix.
+	 */
+	starts_message = sof || raw_rx || eof == TBV_DATA_PDF_FRAME_END;
 	mutex_lock(&tqp->rx_lock);
 	if (tqp->apple_pending_ready_count)
 		tbv_apple_rx_drain_pending_locked(state, tqp);
 	if (sof && tqp->apple_pending_active >= 0)
 		atomic64_inc(&state->apple_rx_sof_while_active);
-	if (tqp->apple_pending_active < 0 && !sof && !raw_rx) {
+	if (tqp->apple_pending_active < 0 && !starts_message) {
 		atomic64_inc(&state->apple_rx_no_sof_when_idle);
 		atomic64_inc(&state->data_rx_bad_frame);
 		mutex_unlock(&tqp->rx_lock);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -43,11 +43,6 @@ module_param(tbnet_identity_gid, charp, 0444);
 MODULE_PARM_DESC(tbnet_identity_gid,
 		 "Netdev whose IPv4 address is proxied as the RDMA GID for tbnet_identity=stock_proxy; auto uses roce_netdev");
 
-static bool tbnet_identity_minimal_e2e;
-module_param(tbnet_identity_minimal_e2e, bool, 0444);
-MODULE_PARM_DESC(tbnet_identity_minimal_e2e,
-		 "Enable E2E flow control on minimal ThunderboltIP packet rings");
-
 static bool tbnet_identity_minimal_apple_only = true;
 module_param(tbnet_identity_minimal_apple_only, bool, 0444);
 MODULE_PARM_DESC(tbnet_identity_minimal_apple_only,
@@ -164,7 +159,6 @@ static int __init tbv_init(void)
 
 	identity_cfg.tbnet_netdev = tbnet_identity_tbnet;
 	identity_cfg.gid_netdev = tbnet_identity_gid;
-	identity_cfg.minimal_e2e = tbnet_identity_minimal_e2e;
 	identity_cfg.minimal_apple_only = tbnet_identity_minimal_apple_only;
 
 	ret = tbv_core_init(&tbv_driver_state, &resolved, &identity_cfg);
@@ -204,13 +198,12 @@ static int __init tbv_init(void)
 		snprintf(lanes_desc, sizeof(lanes_desc), "%u-%u",
 			 cfg.lanes_min, cfg.lanes_max);
 
-	pr_info("loaded compat=%s profile=%s resolved_profile=%s tbnet=%s tbnet_identity=%s tbnet_identity_minimal_e2e=%u tbnet_identity_minimal_apple_only=%u lanes=%s native_control=%s native_data=%u apple_data=%u native_fragment_striping=%u\n",
+	pr_info("loaded compat=%s profile=%s resolved_profile=%s tbnet=%s tbnet_identity=%s tbnet_identity_minimal_apple_only=%u lanes=%s native_control=%s native_data=%u apple_data=%u native_fragment_striping=%u\n",
 		tbv_compat_name(cfg.compat),
 		tbv_profile_name(cfg.profile),
 		tbv_profile_name(resolved.profile),
 		tbv_tbnet_policy_name(cfg.tbnet),
 		tbv_tbnet_identity_name(resolved.tbnet_identity),
-		tbnet_identity_minimal_e2e,
 		tbnet_identity_minimal_apple_only,
 		lanes_desc,
 		tbv_native_control_mode_name(&tbv_driver_state),

--- a/kernel/service.c
+++ b/kernel/service.c
@@ -135,21 +135,21 @@ static bool tbv_service_backend_data_enabled(const struct tbv_state *state,
 	return state->native_data;
 }
 
-static bool tbv_service_tbnet_path_ready(struct tbv_state *state,
-					 const struct tb_xdomain *xd)
+static bool tbv_service_tbnet_neighbor_ready(struct tbv_state *state,
+					     const struct tb_xdomain *xd)
 {
 	if (state->cfg.tbnet_identity != TBV_TBNET_ID_MINIMAL_PACKET)
 		return true;
 
-	return tbv_tbnet_minimal_packet_path_ready(&state->tbnet_identity,
-						   xd ? xd->remote_uuid : NULL);
+	return tbv_tbnet_minimal_neighbor_ready(&state->tbnet_identity,
+						xd ? xd->remote_uuid : NULL);
 }
 
 static bool tbv_service_should_defer_apple_tunnel(struct tbv_state *state,
 						  const struct tb_xdomain *xd)
 {
 	return state->apple_tunnels_wait_tbnet &&
-	       !tbv_service_tbnet_path_ready(state, xd);
+	       !tbv_service_tbnet_neighbor_ready(state, xd);
 }
 
 static bool tbv_service_has_pending_apple_rail_locked(struct tbv_state *state)
@@ -220,7 +220,7 @@ tbv_service_next_pending_apple_rail(struct tbv_state *state)
 			    rail->path.state != TBV_PATH_RING_STARTED)
 				continue;
 			pending = true;
-			if (!tbv_service_tbnet_path_ready(state, peer->xd))
+			if (!tbv_service_tbnet_neighbor_ready(state, peer->xd))
 				continue;
 			refcount_inc(&rail->refcnt);
 			mutex_unlock(&state->lock);
@@ -239,7 +239,7 @@ static void tbv_service_apple_tunnel_work(struct work_struct *work)
 
 	if (!state->services_registered || !state->enable_tunnels)
 		return;
-	if (!tbv_service_tbnet_path_ready(state, NULL))
+	if (!tbv_service_tbnet_neighbor_ready(state, NULL))
 		return;
 
 	for (;;) {
@@ -274,7 +274,7 @@ void tbv_services_tbnet_identity_ready(struct tbv_tbnet_identity *identity)
 		return;
 	if (!state->services_registered || !state->apple_tunnels_wait_tbnet)
 		return;
-	if (!tbv_service_tbnet_path_ready(state, NULL))
+	if (!tbv_service_tbnet_neighbor_ready(state, NULL))
 		return;
 
 	queue_work(system_long_wq, &state->apple_tunnel_work);
@@ -602,13 +602,11 @@ int tbv_services_start(struct tbv_state *state, bool bind_services,
 	state->negotiate_native = service_cfg->negotiate_native;
 	state->enable_tunnels = service_cfg->enable_tunnels;
 	/*
-	 * When this module owns the ThunderboltIP identity, the packet login path
-	 * is the carrier/path proof macOS normally gets from thunderbolt_net.
-	 * Do not program the AD/FA57 tunnel until that identity path is active:
-	 * older macOS interop work showed that enabling a second XDomain DMA
-	 * tunnel before TBnet is established can tear down or poison the peer
-	 * state.  Stock/proxy identity modes already depend on an external TBnet
-	 * carrier, so they keep the immediate FA57 path.
+	 * When this module owns the ThunderboltIP identity, macOS still expects a
+	 * live ThunderboltIP neighbor before the AD/FA57 path is usable.  Do not
+	 * program the AD/FA57 tunnel until the minimal packet path has answered the
+	 * peer's ARP for our RDMA GID address.  Stock/proxy identity modes already
+	 * depend on an external TBnet carrier, so they keep the immediate FA57 path.
 	 */
 	state->apple_tunnels_wait_tbnet =
 		state->cfg.tbnet_identity == TBV_TBNET_ID_MINIMAL_PACKET;

--- a/kernel/service.c
+++ b/kernel/service.c
@@ -135,21 +135,21 @@ static bool tbv_service_backend_data_enabled(const struct tbv_state *state,
 	return state->native_data;
 }
 
-static bool tbv_service_tbnet_neighbor_ready(struct tbv_state *state,
-					     const struct tb_xdomain *xd)
+static bool tbv_service_tbnet_path_ready(struct tbv_state *state,
+					 const struct tb_xdomain *xd)
 {
 	if (state->cfg.tbnet_identity != TBV_TBNET_ID_MINIMAL_PACKET)
 		return true;
 
-	return tbv_tbnet_minimal_neighbor_ready(&state->tbnet_identity,
-						xd ? xd->remote_uuid : NULL);
+	return tbv_tbnet_minimal_packet_path_ready(&state->tbnet_identity,
+						   xd ? xd->remote_uuid : NULL);
 }
 
 static bool tbv_service_should_defer_apple_tunnel(struct tbv_state *state,
 						  const struct tb_xdomain *xd)
 {
 	return state->apple_tunnels_wait_tbnet &&
-	       !tbv_service_tbnet_neighbor_ready(state, xd);
+	       !tbv_service_tbnet_path_ready(state, xd);
 }
 
 static bool tbv_service_has_pending_apple_rail_locked(struct tbv_state *state)
@@ -220,7 +220,7 @@ tbv_service_next_pending_apple_rail(struct tbv_state *state)
 			    rail->path.state != TBV_PATH_RING_STARTED)
 				continue;
 			pending = true;
-			if (!tbv_service_tbnet_neighbor_ready(state, peer->xd))
+			if (!tbv_service_tbnet_path_ready(state, peer->xd))
 				continue;
 			refcount_inc(&rail->refcnt);
 			mutex_unlock(&state->lock);
@@ -239,7 +239,7 @@ static void tbv_service_apple_tunnel_work(struct work_struct *work)
 
 	if (!state->services_registered || !state->enable_tunnels)
 		return;
-	if (!tbv_service_tbnet_neighbor_ready(state, NULL))
+	if (!tbv_service_tbnet_path_ready(state, NULL))
 		return;
 
 	for (;;) {
@@ -274,7 +274,7 @@ void tbv_services_tbnet_identity_ready(struct tbv_tbnet_identity *identity)
 		return;
 	if (!state->services_registered || !state->apple_tunnels_wait_tbnet)
 		return;
-	if (!tbv_service_tbnet_neighbor_ready(state, NULL))
+	if (!tbv_service_tbnet_path_ready(state, NULL))
 		return;
 
 	queue_work(system_long_wq, &state->apple_tunnel_work);
@@ -602,13 +602,16 @@ int tbv_services_start(struct tbv_state *state, bool bind_services,
 	state->negotiate_native = service_cfg->negotiate_native;
 	state->enable_tunnels = service_cfg->enable_tunnels;
 	/*
-	 * Minimal TBnet identity is still advertised so macOS sees a normal
-	 * ThunderboltIP-capable peer, but Apple AD/FA57 data tunnels must not
-	 * depend on macOS bringing the matching IP interface up. macOS can keep
-	 * the RDMA port usable while the enX side is inactive or has not
-	 * exchanged neighbor traffic yet.
+	 * When this module owns the ThunderboltIP identity, the packet login path
+	 * is the carrier/path proof macOS normally gets from thunderbolt_net.
+	 * Do not program the AD/FA57 tunnel until that identity path is active:
+	 * older macOS interop work showed that enabling a second XDomain DMA
+	 * tunnel before TBnet is established can tear down or poison the peer
+	 * state.  Stock/proxy identity modes already depend on an external TBnet
+	 * carrier, so they keep the immediate FA57 path.
 	 */
-	state->apple_tunnels_wait_tbnet = false;
+	state->apple_tunnels_wait_tbnet =
+		state->cfg.tbnet_identity == TBV_TBNET_ID_MINIMAL_PACKET;
 	state->apple_tunnels_pending = false;
 	INIT_WORK(&state->apple_tunnel_work, tbv_service_apple_tunnel_work);
 

--- a/kernel/tbnet_identity.c
+++ b/kernel/tbnet_identity.c
@@ -65,10 +65,6 @@ struct tbv_tbip_login_response {
 	u32 reserved[4];
 };
 
-struct tbv_tbip_logout {
-	struct tbv_tbip_header hdr;
-};
-
 struct tbv_tbip_status {
 	struct tbv_tbip_header hdr;
 	u32 status;
@@ -154,21 +150,6 @@ int tbv_tbip_build_login_response(void *buf, size_t size,
 	msg->status = params->status;
 	memcpy(msg->receiver_mac, params->receiver_mac, TBV_ETH_ALEN);
 	msg->receiver_mac_len = TBV_ETH_ALEN;
-	return sizeof(*msg);
-}
-
-int tbv_tbip_build_logout(void *buf, size_t size,
-			  const struct tbv_tbip_control *ctrl)
-{
-	struct tbv_tbip_logout *msg = buf;
-
-	if (!buf || !ctrl)
-		return -EINVAL;
-	if (size < sizeof(*msg))
-		return -ENOSPC;
-
-	memset(msg, 0, sizeof(*msg));
-	tbv_tbip_fill_header(&msg->hdr, ctrl, TBV_TBIP_LOGOUT, sizeof(*msg));
 	return sizeof(*msg);
 }
 
@@ -287,29 +268,6 @@ int tbv_tbip_parse_login_response(const void *buf, size_t size,
 	result->receiver_mac_len = msg->receiver_mac_len;
 	memcpy(result->receiver_mac, msg->receiver_mac,
 	       min_t(u32, msg->receiver_mac_len, TBV_ETH_ALEN));
-	return 0;
-}
-
-int tbv_tbip_parse_status(const void *buf, size_t size,
-			  struct tbv_tbip_status_result *result)
-{
-	const struct tbv_tbip_status *msg = buf;
-	enum tbv_tbip_type type;
-	int ret;
-
-	if (!result)
-		return -EINVAL;
-	if (size < sizeof(*msg))
-		return -EINVAL;
-
-	memset(result, 0, sizeof(*result));
-	ret = tbv_tbip_parse_header(buf, size, &type, &result->ctrl);
-	if (ret)
-		return ret;
-	if (type != TBV_TBIP_STATUS)
-		return -EPROTO;
-
-	result->status = msg->status;
 	return 0;
 }
 
@@ -847,7 +805,6 @@ int tbv_tbnet_identity_prepare(struct tbv_tbnet_identity *identity,
 
 	memset(identity, 0, sizeof(*identity));
 	identity->mode = cfg->tbnet_identity;
-	identity->minimal_e2e = identity_cfg->minimal_e2e;
 	identity->minimal_apple_only = identity_cfg->minimal_apple_only;
 	mutex_init(&identity->lock);
 	INIT_LIST_HEAD(&identity->minimal_sessions);

--- a/kernel/tbnet_minimal.c
+++ b/kernel/tbnet_minimal.c
@@ -485,6 +485,29 @@ out:
 	return ready;
 }
 
+bool tbv_tbnet_minimal_packet_path_ready(struct tbv_tbnet_identity *identity,
+					 const uuid_t *remote_uuid)
+{
+	struct tbv_tbnet_minimal_session *session;
+	bool ready = false;
+
+	if (identity->mode != TBV_TBNET_ID_MINIMAL_PACKET)
+		return false;
+
+	mutex_lock(&identity->lock);
+	list_for_each_entry(session, &identity->minimal_sessions, node) {
+		if (!READ_ONCE(session->path_enabled))
+			continue;
+		if (remote_uuid &&
+		    !uuid_equal(session->xd->remote_uuid, remote_uuid))
+			continue;
+		ready = true;
+		break;
+	}
+	mutex_unlock(&identity->lock);
+	return ready;
+}
+
 void tbv_tbnet_minimal_clear_neighbors_locked(struct tbv_tbnet_identity *identity)
 {
 	struct tbv_tbnet_minimal_session *session;
@@ -499,14 +522,14 @@ void tbv_tbnet_minimal_clear_neighbors_locked(struct tbv_tbnet_identity *identit
 
 static void tbv_tbnet_minimal_recompute_state(struct tbv_tbnet_identity *identity)
 {
-	bool ready;
+	bool path_ready;
 
 	mutex_lock(&identity->lock);
 	tbv_tbnet_minimal_recompute_state_locked(identity);
-	ready = identity->state & TBV_TBNET_ID_STATE_NEIGHBOR_READY;
+	path_ready = identity->state & TBV_TBNET_ID_STATE_PACKET_PATH_ACTIVE;
 	mutex_unlock(&identity->lock);
 
-	if (ready)
+	if (path_ready)
 		tbv_services_tbnet_identity_ready(identity);
 }
 

--- a/kernel/tbnet_minimal.c
+++ b/kernel/tbnet_minimal.c
@@ -43,6 +43,9 @@
 #define TBV_TBNET_E2E			BIT(0)
 #define TBV_TBNET_MATCH_FRAGS_ID	BIT(1)
 #define TBV_TBNET_64K_FRAMES		BIT(2)
+/* Matches Apple's ThunderboltIP service advertisement. Ring E2E stays separate. */
+#define TBV_TBNET_APPLE_PRTCSTNS	(BIT(31) | TBV_TBNET_MATCH_FRAGS_ID | \
+					 TBV_TBNET_E2E)
 #define TBV_TBNET_L0_PORT_NUM(route)	((route) & GENMASK(5, 0))
 #define TBV_TBNET_PDF_FRAME_START	1
 #define TBV_TBNET_PDF_FRAME_END		2
@@ -1478,7 +1481,7 @@ static struct tb_service_driver tbv_tbnet_minimal_driver = {
 
 int tbv_tbnet_minimal_start(struct tbv_tbnet_identity *identity)
 {
-	u32 prtcstns = TBV_TBNET_MATCH_FRAGS_ID | TBV_TBNET_64K_FRAMES;
+	u32 prtcstns = TBV_TBNET_APPLE_PRTCSTNS;
 	int ret;
 
 	if (identity->minimal_started)

--- a/kernel/tbnet_minimal.c
+++ b/kernel/tbnet_minimal.c
@@ -357,17 +357,19 @@ static int tbv_tbnet_minimal_prime_rx(struct tbv_tbnet_minimal_session *session)
 static int
 tbv_tbnet_minimal_alloc_rings(struct tbv_tbnet_minimal_session *session)
 {
-	unsigned int flags = RING_FLAG_FRAME;
+	unsigned int rx_flags = RING_FLAG_FRAME;
+	unsigned int tx_flags = RING_FLAG_FRAME;
 	u16 sof_mask = BIT(TBV_TBNET_PDF_FRAME_START);
 	u16 eof_mask = BIT(TBV_TBNET_PDF_FRAME_END);
 	int hopid;
 	int ret;
 
 	if (session->svc->prtcstns & TBV_TBNET_E2E)
-		flags |= RING_FLAG_E2E;
+		rx_flags |= RING_FLAG_E2E;
 
 	session->tx_ring = tb_ring_alloc_tx(session->xd->tb->nhi, -1,
-					    TBV_TBNET_MIN_RING_SIZE, flags);
+					    TBV_TBNET_MIN_RING_SIZE,
+					    tx_flags);
 	if (!session->tx_ring)
 		return -ENOMEM;
 
@@ -379,7 +381,8 @@ tbv_tbnet_minimal_alloc_rings(struct tbv_tbnet_minimal_session *session)
 	session->local_transmit_path = hopid;
 
 	session->rx_ring = tb_ring_alloc_rx(session->xd->tb->nhi, -1,
-					    TBV_TBNET_MIN_RING_SIZE, flags,
+					    TBV_TBNET_MIN_RING_SIZE,
+					    rx_flags,
 					    session->tx_ring->hop,
 					    sof_mask, eof_mask,
 					    tbv_tbnet_minimal_rx_ready,

--- a/kernel/tbnet_minimal.c
+++ b/kernel/tbnet_minimal.c
@@ -37,7 +37,6 @@
 #define TBV_TBNET_MIN_LOGIN_DELAY_MS	4500
 #define TBV_TBNET_MIN_LOGIN_TIMEOUT_MS	500
 #define TBV_TBNET_MIN_LOGIN_RETRIES	60
-#define TBV_TBNET_MIN_LOGOUT_TIMEOUT_MS	1000
 #define TBV_TBNET_MIN_RING_SIZE		256
 #define TBV_TBNET_MIN_FRAME_SIZE	SZ_4K
 #define TBV_TBNET_E2E			BIT(0)
@@ -97,7 +96,6 @@ struct tbv_tbnet_minimal_session {
 	bool path_enabled;
 	bool login_sent;
 	bool login_received;
-	bool logout_reset_sent;
 	bool neighbor_seen;
 	bool handler_registered;
 	bool removing;
@@ -145,9 +143,6 @@ static void tbv_tbnet_minimal_rx_work(struct work_struct *work);
 static void tbv_tbnet_minimal_tx_poll_work(struct work_struct *work);
 static void
 tbv_tbnet_minimal_free_rings(struct tbv_tbnet_minimal_session *session);
-static int
-tbv_tbnet_minimal_send_logout_request(struct tbv_tbnet_minimal_session *session,
-				      u8 sequence);
 static __be32
 tbv_tbnet_minimal_lookup_proxy_ipv4(struct tbv_tbnet_identity *identity);
 
@@ -368,8 +363,7 @@ tbv_tbnet_minimal_alloc_rings(struct tbv_tbnet_minimal_session *session)
 	int hopid;
 	int ret;
 
-	if (session->identity->minimal_e2e &&
-	    session->svc->prtcstns & TBV_TBNET_E2E)
+	if (session->svc->prtcstns & TBV_TBNET_E2E)
 		flags |= RING_FLAG_E2E;
 
 	session->tx_ring = tb_ring_alloc_tx(session->xd->tb->nhi, -1,
@@ -921,7 +915,6 @@ static void tbv_tbnet_minimal_teardown_path(struct tbv_tbnet_minimal_session *s)
 	}
 	s->login_sent = false;
 	s->login_received = false;
-	s->logout_reset_sent = false;
 	s->login_retries = 0;
 	mutex_unlock(&s->lock);
 
@@ -1013,7 +1006,6 @@ static void tbv_tbnet_minimal_login_work(struct work_struct *work)
 	struct tbv_tbip_login_params params;
 	u8 request[128];
 	u8 reply[128];
-	bool need_reset;
 	bool retry_later = false;
 	u8 sequence;
 	int ret;
@@ -1025,17 +1017,7 @@ static void tbv_tbnet_minimal_login_work(struct work_struct *work)
 		return;
 	}
 	sequence = session->login_retries % 4;
-	need_reset = !session->login_received && !session->logout_reset_sent;
-	if (need_reset)
-		session->logout_reset_sent = true;
 	mutex_unlock(&session->lock);
-
-	if (need_reset) {
-		ret = tbv_tbnet_minimal_send_logout_request(session, sequence);
-		if (ret && ret != -ETIMEDOUT && ret != -ENODEV)
-			pr_debug("minimal TBnet logout reset route=0x%llx ret=%d\n",
-				 session->xd->route, ret);
-	}
 
 	mutex_lock(&session->lock);
 	if (session->path_enabled || session->removing) {
@@ -1139,50 +1121,6 @@ static int tbv_tbnet_minimal_send_status(
 
 	return tb_xdomain_response(session->xd, reply, len,
 				   TB_CFG_PKG_XDOMAIN_RESP);
-}
-
-static int
-tbv_tbnet_minimal_send_logout_request(struct tbv_tbnet_minimal_session *session,
-				      u8 sequence)
-{
-	struct tbv_tbip_status_result status;
-	struct tbv_tbip_control ctrl;
-	u8 request[128];
-	u8 reply[128];
-	int ret;
-	int len;
-
-	memset(&ctrl, 0, sizeof(ctrl));
-	ctrl.route = session->xd->route;
-	ctrl.sequence = sequence;
-	uuid_copy(&ctrl.initiator_uuid, session->xd->local_uuid);
-	uuid_copy(&ctrl.target_uuid, session->xd->remote_uuid);
-	ctrl.command_id = atomic_inc_return(&session->command_id);
-
-	len = tbv_tbip_build_logout(request, sizeof(request), &ctrl);
-	if (len < 0)
-		return len;
-
-	memset(reply, 0, sizeof(reply));
-	atomic64_inc(&session->identity->minimal_logout_tx);
-	atomic64_inc(&session->logout_tx);
-	ret = tb_xdomain_request(session->xd, request, len,
-				 TB_CFG_PKG_XDOMAIN_RESP, reply, sizeof(reply),
-				 TB_CFG_PKG_XDOMAIN_RESP,
-				 TBV_TBNET_MIN_LOGOUT_TIMEOUT_MS);
-	if (!ret)
-		ret = tbv_tbip_parse_status(reply, sizeof(reply), &status);
-	if (!ret &&
-	    (!tbv_tbnet_minimal_ctrl_matches(session, &status.ctrl) ||
-	     status.status)) {
-		ret = -EPROTO;
-	}
-	if (!ret) {
-		atomic64_inc(&session->identity->minimal_status_rx);
-		atomic64_inc(&session->status_rx);
-	}
-
-	return ret;
 }
 
 static int tbv_tbnet_minimal_handle_packet_common(
@@ -1385,8 +1323,7 @@ static int tbv_tbnet_minimal_probe(struct tb_service *svc,
 	mutex_unlock(&identity->lock);
 
 	tb_service_set_drvdata(svc, session);
-	queue_delayed_work(system_long_wq, &session->login_work,
-			   msecs_to_jiffies(1000));
+	queue_delayed_work(system_long_wq, &session->login_work, 0);
 	pr_info("bound minimal TBnet service id=%d route=0x%llx tx_path=%d mac=%pM prtcstns=0x%x\n",
 		svc->id, xd->route, session->local_transmit_path,
 		session->mac, svc->prtcstns);
@@ -1496,8 +1433,6 @@ int tbv_tbnet_minimal_start(struct tbv_tbnet_identity *identity)
 					       "prtcvers", 1);
 	ret = ret ?: tb_property_add_immediate(identity->minimal_dir,
 					       "prtcrevs", 1);
-	if (identity->minimal_e2e)
-		prtcstns |= TBV_TBNET_E2E;
 	ret = ret ?: tb_property_add_immediate(identity->minimal_dir,
 					       "prtcstns",
 					       prtcstns);

--- a/kernel/tbv.h
+++ b/kernel/tbv.h
@@ -691,6 +691,8 @@ int tbv_tbnet_arp_reply_for_request(void *reply, size_t reply_size,
 int tbv_tbnet_minimal_start(struct tbv_tbnet_identity *identity);
 void tbv_tbnet_minimal_stop(struct tbv_tbnet_identity *identity);
 void tbv_tbnet_minimal_recompute_state_locked(struct tbv_tbnet_identity *identity);
+bool tbv_tbnet_minimal_packet_path_ready(struct tbv_tbnet_identity *identity,
+					 const uuid_t *remote_uuid);
 bool tbv_tbnet_minimal_neighbor_ready(struct tbv_tbnet_identity *identity,
 				      const uuid_t *remote_uuid);
 void tbv_tbnet_minimal_clear_neighbors_locked(struct tbv_tbnet_identity *identity);

--- a/kernel/tbv.h
+++ b/kernel/tbv.h
@@ -334,7 +334,6 @@ struct tbv_tbnet_identity {
 	struct notifier_block netdev_nb;
 	struct notifier_block inetaddr_nb;
 	__be32 proxy_ipv4;
-	bool minimal_e2e;
 	bool minimal_apple_only;
 	bool minimal_neighbor_seen;
 	bool minimal_dir_registered;
@@ -391,11 +390,6 @@ struct tbv_tbip_status_params {
 	u32 status;
 };
 
-struct tbv_tbip_status_result {
-	struct tbv_tbip_control ctrl;
-	u32 status;
-};
-
 struct tbv_tbip_login_response_result {
 	struct tbv_tbip_control ctrl;
 	u32 status;
@@ -411,7 +405,6 @@ struct tbv_tbnet_arp_proxy {
 struct tbv_tbnet_identity_config {
 	const char *tbnet_netdev;
 	const char *gid_netdev;
-	bool minimal_e2e;
 	bool minimal_apple_only;
 };
 
@@ -672,8 +665,6 @@ int tbv_tbip_build_login(void *buf, size_t size,
 			 const struct tbv_tbip_login_params *params);
 int tbv_tbip_build_login_response(void *buf, size_t size,
 				  const struct tbv_tbip_login_response_params *params);
-int tbv_tbip_build_logout(void *buf, size_t size,
-			  const struct tbv_tbip_control *ctrl);
 int tbv_tbip_build_status(void *buf, size_t size,
 			  const struct tbv_tbip_status_params *params);
 int tbv_tbip_parse_type(const void *buf, size_t size,
@@ -683,8 +674,6 @@ int tbv_tbip_parse_login(const void *buf, size_t size,
 			 struct tbv_tbip_login_params *params);
 int tbv_tbip_parse_login_response(const void *buf, size_t size,
 				  struct tbv_tbip_login_response_result *result);
-int tbv_tbip_parse_status(const void *buf, size_t size,
-			  struct tbv_tbip_status_result *result);
 int tbv_tbnet_arp_reply_for_request(void *reply, size_t reply_size,
 				    const void *request, size_t request_size,
 				    const struct tbv_tbnet_arp_proxy *proxy);


### PR DESCRIPTION
## Summary

- gate Apple AD/FA57 tunnel enablement on the minimal ThunderboltIP packet path becoming active
- keep the existing neighbor/ARP readiness predicate separate from packet-path readiness, avoiding a bootstrap deadlock
- queue deferred FA57 tunnel work as soon as the minimal TBnet LOGIN/path is active

## Why

Historical Apple interop notes and the current router/goblin trace both point at setup ordering, not an AD/FA57 private control protocol. The `798f589e-...` stream is ThunderboltIP. When we provide the minimal ThunderboltIP identity ourselves, enabling the FA57 XDomain DMA tunnel immediately after FA57 ring start can race ahead of the TBnet packet path that macOS expects to exist.

## Validation

- `git diff --check`
- `nix flake check --no-build`
- `nix build .#checks.x86_64-linux.thunderbolt-ibverbs -L`
- `nix build .#checks.x86_64-linux.proto-smoke .#checks.x86_64-linux.script-syntax .#checks.x86_64-linux.verbs-smoke-build -L`
- built router NixOS closure against this branch using `--override-input thunderbolt-ibverbs-kernel path:/mnt/Home/src/thunderbolt-ibverbs-apple-wait-tbnet`
- copied closure to router and reloaded only `thunderbolt_ibverbs` with the generated helper on booted kernel `7.0.10`: `thunderbolt-ibverbs-check: ok`
- router debugfs after reload confirms `tbnet_identity_proxy_ipv4: 10.0.3.44` and `apple_tunnels_wait_tbnet: 1`

Live router/goblin data-path validation is still pending: the router-facing Thunderbolt link is currently not producing a Linux XDomain peer, and goblin reports only the MBP XDomain as connected.
