### PR TITLE
kernel: consolidate correctness fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,20 @@ if you want a batteries-included image with vllm / llama.cpp / rdma-core-usb4 / 
 ## that sounds complicated, is there any easier way?
 sure, download and write the usb-bootable image from here, insert it into your machines, hit f11 while its booting to select the usb stick
 
-TODO: instructions for how to start vllm once its booted. check benchmark/test scripts for reference.
+For a repeatable two-node vLLM transport smoke, use the packaged bench helper.
+It starts Ray, runs a tiny TP=2 vLLM workload, captures
+`/sys/kernel/debug/thunderbolt_ibverbs/summary` before/after, and fails if the
+TP run completes without moving RDMA counters:
+
+```sh
+tbv_vllm_smoke.sh \
+  --hosts 192.168.23.136,192.168.23.192 \
+  --iface eno1 \
+  --transport native \
+  --hca usb4_rdma5 \
+  --wrapper /path/to/vllm-env \
+  --require-rdma auto
+```
 
 ## Status
 
@@ -193,6 +206,16 @@ nix build github:hellas-ai/thunderbolt-ibverbs#bench-tools      # u4_pingpong, u
 
 `nix develop` drops you in a shell with the module headers, `rdma-core-usb4`,
 `perftest`, and the bench tools on PATH.
+
+For benchmark hosts that need SSH aliases or a jump host, pass an SSH config to
+the generated runner:
+
+```sh
+nix run .#tbv-perftest -- \
+  --ssh-config /tmp/tbv_ssh_config \
+  --hosts goblin,mbp-tb \
+  --data-addrs goblin=192.168.0.1,mbp-tb=192.168.0.2
+```
 
 On NixOS, add the flake input and import the module:
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -94,4 +94,50 @@ nix run .#tbv-perftest -- --hosts strix-1,strix-2 \
   --tag rxe-tbnet --csv "$out/rxe-tbnet.csv" --jsonl "$out/rxe-tbnet.jsonl"
 ```
 
+## Apple Thunderbolt RDMA
+
+Apple `rdma_en*` devices need the Thunderbolt interface, not `bridge0`, to own
+the per-port test IP. Use MLX's configurator or equivalent `ifconfig` setup
+before running perftest; this creates the IPv4-mapped GID at index 1 that
+JACCL and Apple's provider expect.
+
+```sh
+# Run from the first Mac. Use LAN/Wi-Fi/Ethernet SSH names here, not the
+# Thunderbolt data addresses.
+mlx.distributed_config \
+  --hosts localhost,<peer-lan-host-or-ip> \
+  --over thunderbolt \
+  --backend jaccl \
+  --auto-setup \
+  --output-hostfile /tmp/mlx_hosts_auto.json
+```
+
+When SSH and RDMA use different addresses, tell `tbv-perftest` both. The
+runner still SSHs `--server` / `--client`, but passes `--*-data-addr` to the
+perftest client so address exchange selects the Thunderbolt GID.
+
+```sh
+# Example: goblin rdma_en2 at 192.168.0.1, mbp rdma_en3 at 192.168.0.2.
+nix run .#tbv-perftest -- \
+  --server goblin \
+  --client 192.168.23.240 \
+  --server-dev rdma_en2 \
+  --client-dev rdma_en3 \
+  --server-data-addr 192.168.0.1 \
+  --client-data-addr 192.168.0.2 \
+  --only 'bw.uc.ib_send_bw.size65536.qps1' \
+  --only 'lat.uc.ib_send_lat.size4096' \
+  --directions both \
+  --no-rail-check \
+  --tag apple-uc-smoke \
+  --csv "$out/apple-uc-smoke.csv" \
+  --jsonl "$out/apple-uc-smoke.jsonl"
+```
+
+For `rdma_en*` UC cases the runner defaults to `--gid-index 1`, `--mtu 1024`,
+and caps UC SEND queue depths at 32. These defaults match the working JACCL
+shape. UC SEND is the reliable Apple smoke path; UC WRITE cases are still useful
+for investigation but can hang or report misleading bandwidth depending on the
+peer implementation.
+
 Historical checked-in result sets live under `bench/results/`.

--- a/flake.lock
+++ b/flake.lock
@@ -3,10 +3,10 @@
     "linux-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779802034,
-        "narHash": "sha256-AtgoTQnF7yPt7dyYJjQIy8zt1JGdebkHSmVcoUxu7Xo=",
+        "lastModified": 1780549139,
+        "narHash": "sha256-HkhLiKigaUCQeH6z5enWhExJtW2LLh4NHVBrSlZc3XU=",
         "ref": "refs/heads/next",
-        "rev": "d73a08958e66849ea713d2f458b2fcf7b183f987",
+        "rev": "503c5ae1e72aa9ed91925dafa3d82ee2e992747f",
         "shallow": true,
         "type": "git",
         "url": "https://git.kernel.org/pub/scm/linux/kernel/git/westeri/thunderbolt.git"

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
       integrationThunderboltKernelPatches = import ./kernel-workflow/patches/local.nix;
       kernelPatchSets = {
         kernelPatches = portableThunderboltKernelPatches;
+        portableKernelPatches = portableThunderboltKernelPatches;
         integrationKernelPatches = integrationThunderboltKernelPatches;
         upstreamKernelPatches = upstreamThunderboltKernelPatches;
         portableLocalKernelPatches = portableLocalThunderboltKernelPatches;
@@ -115,7 +116,8 @@
               tools/ci/distro-package-rdma.sh \
               tools/ci/distro-package.sh \
               tools/ci/vm-guest-smoke.sh \
-              tools/ci/vm-smoke.sh
+              tools/ci/vm-smoke.sh \
+              userspace/bench/tbv_vllm_smoke.sh
             runHook postBuild
           '';
 

--- a/kernel-workflow/patches/0009-thunderbolt-xdomain-lane-bonding-module-param.patch
+++ b/kernel-workflow/patches/0009-thunderbolt-xdomain-lane-bonding-module-param.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: georgewhewell <georgerw@gmail.com>
+Date: Fri, 5 Jun 2026 02:25:00 +0200
+Subject: [PATCH] thunderbolt: add XDomain lane bonding module parameter
+
+Add a debug module parameter that can skip the automatic XDomain lane
+bonding handshake while leaving the default behavior unchanged.
+
+This is useful when investigating non-standard topologies where the two
+domains report asymmetric link state through an intermediate hub.
+---
+ drivers/thunderbolt/xdomain.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+index 7e0d0641242a..47fd0994b919 100644
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -53,6 +53,11 @@ static const char * const state_names[] = {
+ 	[XDOMAIN_STATE_ERROR] = "ERROR",
+ };
+ 
++static bool xdomain_lane_bonding = true;
++module_param_named(xdomain_lane_bonding, xdomain_lane_bonding, bool, 0644);
++MODULE_PARM_DESC(xdomain_lane_bonding,
++		 "enable automatic XDomain lane bonding (default: true)");
++
+ struct xdomain_request_work {
+ 	struct work_struct work;
+ 	struct tb_xdp_header *pkg;
+@@ -1726,10 +1731,14 @@ static void tb_xdomain_state_work(struct work_struct *work)
+ 			tb_xdomain_failed(xd);
+ 		} else {
+ 			tb_xdomain_queue_properties_changed(xd);
+-			if (xd->bonding_possible)
+-				tb_xdomain_queue_link_status(xd);
+-			else
+-				tb_xdomain_queue_properties(xd);
++			if (xd->bonding_possible && xdomain_lane_bonding) {
++				tb_xdomain_queue_link_status(xd);
++			} else {
++				if (xd->bonding_possible)
++					dev_dbg(&xd->dev,
++						"XDomain lane bonding disabled by module parameter\n");
++				tb_xdomain_queue_properties(xd);
++			}
+ 		}
+ 		break;
+ 
+-- 
+2.53.0

--- a/kernel-workflow/patches/0009-thunderbolt-xdomain-match-properties-by-identity.patch
+++ b/kernel-workflow/patches/0009-thunderbolt-xdomain-match-properties-by-identity.patch
@@ -1,0 +1,199 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: georgewhewell <georgerw@gmail.com>
+Date: Sun, 7 Jun 2026 00:00:00 +0000
+Subject: [PATCH] thunderbolt: xdomain: match properties responses by identity
+
+macOS can send valid XDomain PROPERTIES_RESPONSE packets whose XDomain
+sequence bits do not match the request currently waiting in Linux.  The
+property response already carries a stronger transaction identity: the
+reply source/destination UUIDs and the property block offset.
+
+Validate those fields in the matcher and when consuming the response.
+Also copy only the bytes actually present in the received frame and avoid
+casting short scheduled request packets.
+
+Signed-off-by: georgewhewell <georgerw@gmail.com>
+---
+ drivers/thunderbolt/xdomain.c | 99 +++++++++++++++++++++++++++++++++--
+ 1 file changed, 94 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+index d45f032..ccc04a2 100644
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -55,6 +55,7 @@ static const char * const state_names[] = {
+ struct xdomain_request_work {
+ 	struct work_struct work;
+ 	struct tb_xdp_header *pkg;
++	size_t pkg_len;
+ 	struct tb *tb;
+ };
+ 
+@@ -86,6 +87,66 @@ bool tb_is_xdomain_enabled(void)
+ 	return tb_xdomain_enabled && tb_acpi_is_xdomain_allowed();
+ }
+ 
++static size_t tb_xdomain_frame_payload_size(const struct ctl_pkg *pkg)
++{
++	return pkg->frame.size;
++}
++
++static u16 tb_xdp_length(const struct tb_xdp_header *hdr)
++{
++	return hdr->xd_hdr.length_sn & TB_XDOMAIN_LENGTH_MASK;
++}
++
++static bool tb_xdomain_match_properties(const struct tb_cfg_request *req,
++					const struct ctl_pkg *pkg)
++{
++	const struct tb_xdp_properties *prop_req = req->request;
++	const struct tb_xdp_properties_response *res = pkg->buffer;
++	const struct tb_xdp_header *res_hdr = pkg->buffer;
++	size_t payload_size = tb_xdomain_frame_payload_size(pkg);
++	size_t packet_size;
++	u16 chunk_len;
++	u16 xdp_len;
++
++	if (req->request_size < sizeof(*prop_req))
++		return false;
++	if (payload_size < sizeof(*res_hdr))
++		return false;
++
++	if (res_hdr->type == ERROR_RESPONSE)
++		return payload_size >= sizeof(struct tb_xdp_error_response);
++	if (res_hdr->type != PROPERTIES_RESPONSE)
++		return false;
++	if (payload_size < sizeof(*res))
++		return false;
++
++	xdp_len = tb_xdp_length(res_hdr);
++	if (xdp_len < sizeof(*res) / 4 - sizeof(res_hdr->xd_hdr) / 4)
++		return false;
++
++	packet_size = (xdp_len + sizeof(res_hdr->xd_hdr) / 4) * 4;
++	if (packet_size < sizeof(*res) || packet_size > payload_size)
++		return false;
++
++	if (!uuid_equal(&res->src_uuid, &prop_req->dst_uuid) ||
++	    !uuid_equal(&res->dst_uuid, &prop_req->src_uuid))
++		return false;
++
++	if (res->offset != prop_req->offset)
++		return false;
++	if (!res->data_length ||
++	    res->data_length > TB_XDP_PROPERTIES_MAX_LENGTH)
++		return false;
++	if (res->offset > res->data_length)
++		return false;
++
++	chunk_len = (packet_size - sizeof(*res)) / 4;
++	if (chunk_len > res->data_length - res->offset)
++		return false;
++
++	return true;
++}
++
+ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ 			     const struct ctl_pkg *pkg)
+ {
+@@ -97,7 +158,7 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ 		const struct tb_xdp_header *res_hdr = pkg->buffer;
+ 		const struct tb_xdp_header *req_hdr = req->request;
+ 
+-		if (pkg->frame.size < req->response_size / 4)
++		if (tb_xdomain_frame_payload_size(pkg) < sizeof(*res_hdr))
+ 			return false;
+ 
+ 		/* Make sure route matches */
+@@ -111,6 +172,13 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ 		if (!uuid_equal(&res_hdr->uuid, &req_hdr->uuid))
+ 			return false;
+ 
++		if (uuid_equal(&req_hdr->uuid, &tb_xdp_uuid) &&
++		    req_hdr->type == PROPERTIES_REQUEST)
++			return tb_xdomain_match_properties(req, pkg);
++
++		if (pkg->frame.size < req->response_size / 4)
++			return false;
++
+ 		return true;
+ 	}
+ 
+@@ -122,7 +190,11 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ static bool tb_xdomain_copy(struct tb_cfg_request *req,
+ 			    const struct ctl_pkg *pkg)
+ {
+-	memcpy(req->response, pkg->buffer, req->response_size);
++	size_t len = min_t(size_t, tb_xdomain_frame_payload_size(pkg),
++			   req->response_size);
++
++	memset(req->response, 0, req->response_size);
++	memcpy(req->response, pkg->buffer, len);
+ 	req->result.err = 0;
+ 	return true;
+ }
+@@ -367,7 +439,7 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 		 * least size of the response structure.
+ 		 */
+ 		len = res->hdr.xd_hdr.length_sn & TB_XDOMAIN_LENGTH_MASK;
+-		if (len < sizeof(*res) / 4) {
++		if (len < sizeof(*res) / 4 - sizeof(res->hdr.xd_hdr) / 4) {
+ 			ret = -EINVAL;
+ 			goto err;
+ 		}
+@@ -375,11 +447,26 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 		len += sizeof(res->hdr.xd_hdr) / 4;
+ 		len -= sizeof(*res) / 4;
+ 
++		if (!uuid_equal(&res->src_uuid, dst_uuid) ||
++		    !uuid_equal(&res->dst_uuid, src_uuid)) {
++			ret = -EINVAL;
++			goto err;
++		}
++
+ 		if (res->offset != req.offset) {
+ 			ret = -EINVAL;
+ 			goto err;
+ 		}
+ 
++		if (!res->data_length ||
++		    res->data_length > TB_XDP_PROPERTIES_MAX_LENGTH ||
++		    (data && res->data_length != data_len) ||
++		    res->offset > res->data_length ||
++		    len > res->data_length - res->offset) {
++			ret = -EINVAL;
++			goto err;
++		}
++
+ 		/*
+ 		 * First time allocate block that has enough space for
+ 		 * the whole properties block.
+@@ -786,7 +873,7 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 	switch (pkg->type) {
+ 	case PROPERTIES_REQUEST:
+ 		tb_dbg(tb, "%llx: received XDomain properties request\n", route);
+-		if (xd) {
++		if (xd && xw->pkg_len >= sizeof(struct tb_xdp_properties)) {
+ 			ret = tb_xdp_properties_response(tb, ctl, xd, sequence,
+ 				(const struct tb_xdp_properties *)pkg);
+ 		}
+@@ -879,7 +966,8 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 		tb_dbg(tb, "%llx: received XDomain link state change request\n",
+ 		       route);
+ 
+-		if (xd && xd->state == XDOMAIN_STATE_BONDING_UUID_HIGH) {
++		if (xd && xd->state == XDOMAIN_STATE_BONDING_UUID_HIGH &&
++		    xw->pkg_len >= sizeof(struct tb_xdp_link_state_change)) {
+ 			const struct tb_xdp_link_state_change *lsc =
+ 				(const struct tb_xdp_link_state_change *)pkg;
+ 
+@@ -932,6 +1020,7 @@ tb_xdp_schedule_request(struct tb *tb, const struct tb_xdp_header *hdr,
+ 		kfree(xw);
+ 		return false;
+ 	}
++	xw->pkg_len = size;
+ 	xw->tb = tb_domain_get(tb);
+ 
+ 	schedule_work(&xw->work);
+-- 
+2.54.0

--- a/kernel-workflow/patches/0010-thunderbolt-trace-XDomain-route-matching.patch
+++ b/kernel-workflow/patches/0010-thunderbolt-trace-XDomain-route-matching.patch
@@ -1,0 +1,576 @@
+From 5b4a9b9c071dfa82f90b5518f9f4cec0781b2e7d Mon Sep 17 00:00:00 2001
+From: georgewhewell <georgerw@gmail.com>
+Date: Sat, 6 Jun 2026 14:16:52 +0200
+Subject: [PATCH] thunderbolt: trace XDomain route matching
+
+Signed-off-by: georgewhewell <georgerw@gmail.com>
+---
+ drivers/thunderbolt/icm.c     |   5 +
+ drivers/thunderbolt/tb.h      |   1 +
+ drivers/thunderbolt/xdomain.c | 297 +++++++++++++++++++++++++++++++++-
+ 3 files changed, 295 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/thunderbolt/icm.c b/drivers/thunderbolt/icm.c
+index 10fefac3b1d9..2956cd1772cb 100644
+--- a/drivers/thunderbolt/icm.c
++++ b/drivers/thunderbolt/icm.c
+@@ -732,6 +732,11 @@ static void add_xdomain(struct tb_switch *sw, u64 route,
+ 
+ static void update_xdomain(struct tb_xdomain *xd, u64 route, u8 link)
+ {
++	if (tb_xdomain_debug_enabled())
++		dev_info(&xd->dev, "XDomain ICM update route old=%llx new=%llx link old=%u new=%u depth=%u remote=%pUb\n",
++			 xd->route, route, xd->link, link, xd->depth,
++			 xd->remote_uuid);
++
+ 	xd->link = link;
+ 	xd->route = route;
+ 	xd->is_unplugged = false;
+diff --git a/drivers/thunderbolt/tb.h b/drivers/thunderbolt/tb.h
+index ec9192b61bc0..a68c53f21257 100644
+--- a/drivers/thunderbolt/tb.h
++++ b/drivers/thunderbolt/tb.h
+@@ -1257,6 +1257,7 @@ static inline u64 tb_downstream_route(struct tb_port *port)
+ }
+ 
+ bool tb_is_xdomain_enabled(void);
++bool tb_xdomain_debug_enabled(void);
+ bool tb_xdomain_handle_request(struct tb *tb, enum tb_cfg_pkg_type type,
+ 			       const void *buf, size_t size);
+ struct tb_xdomain *tb_xdomain_alloc(struct tb *tb, struct device *parent,
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+index 86b2f7474670..61d316af3b47 100644
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -63,6 +63,11 @@ static bool tb_xdomain_enabled = true;
+ module_param_named(xdomain, tb_xdomain_enabled, bool, 0444);
+ MODULE_PARM_DESC(xdomain, "allow XDomain protocol (default: true)");
+ 
++static bool xdomain_debug;
++module_param_named(xdomain_debug, xdomain_debug, bool, 0644);
++MODULE_PARM_DESC(xdomain_debug,
++		 "log XDomain discovery packets and route matching decisions");
++
+ /*
+  * Serializes access to the properties and protocol handlers below. If
+  * you need to take both this lock and the struct tb_xdomain lock, take
+@@ -82,11 +87,65 @@ static const uuid_t tb_xdp_uuid =
+ 	UUID_INIT(0xb638d70e, 0x42ff, 0x40bb,
+ 		  0x97, 0xc2, 0x90, 0xe2, 0xc0, 0xb2, 0xff, 0x07);
+ 
++static u64 tb_xdp_route(const struct tb_xdp_header *hdr)
++{
++	return ((u64)(hdr->xd_hdr.route_hi & ~BIT(31)) << 32) |
++	       hdr->xd_hdr.route_lo;
++}
++
++static u8 tb_xdp_sequence(const struct tb_xdp_header *hdr)
++{
++	return (hdr->xd_hdr.length_sn & TB_XDOMAIN_SN_MASK) >>
++		TB_XDOMAIN_SN_SHIFT;
++}
++
++static u16 tb_xdp_length(const struct tb_xdp_header *hdr)
++{
++	return hdr->xd_hdr.length_sn & TB_XDOMAIN_LENGTH_MASK;
++}
++
++static const char *tb_xdp_type_name(enum tb_xdp_type type)
++{
++	switch (type) {
++	case UUID_REQUEST_OLD:
++		return "UUID_REQUEST_OLD";
++	case UUID_RESPONSE:
++		return "UUID_RESPONSE";
++	case PROPERTIES_REQUEST:
++		return "PROPERTIES_REQUEST";
++	case PROPERTIES_RESPONSE:
++		return "PROPERTIES_RESPONSE";
++	case PROPERTIES_CHANGED_REQUEST:
++		return "PROPERTIES_CHANGED_REQUEST";
++	case PROPERTIES_CHANGED_RESPONSE:
++		return "PROPERTIES_CHANGED_RESPONSE";
++	case ERROR_RESPONSE:
++		return "ERROR_RESPONSE";
++	case UUID_REQUEST:
++		return "UUID_REQUEST";
++	case LINK_STATE_STATUS_REQUEST:
++		return "LINK_STATE_STATUS_REQUEST";
++	case LINK_STATE_STATUS_RESPONSE:
++		return "LINK_STATE_STATUS_RESPONSE";
++	case LINK_STATE_CHANGE_REQUEST:
++		return "LINK_STATE_CHANGE_REQUEST";
++	case LINK_STATE_CHANGE_RESPONSE:
++		return "LINK_STATE_CHANGE_RESPONSE";
++	default:
++		return "UNKNOWN";
++	}
++}
++
+ bool tb_is_xdomain_enabled(void)
+ {
+ 	return tb_xdomain_enabled && tb_acpi_is_xdomain_allowed();
+ }
+ 
++bool tb_xdomain_debug_enabled(void)
++{
++	return xdomain_debug;
++}
++
+ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ 			     const struct ctl_pkg *pkg)
+ {
+@@ -98,19 +157,76 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ 		const struct tb_xdp_header *res_hdr = pkg->buffer;
+ 		const struct tb_xdp_header *req_hdr = req->request;
+ 
+-		if (pkg->frame.size < req->response_size / 4)
++		if (pkg->frame.size < req->response_size / 4) {
++			if (xdomain_debug)
++				pr_info_ratelimited("thunderbolt xdomain: match drop short response req_type=%s(%#x) frame_size=%u expected_cmp=%zu response_size=%zu\n",
++						    tb_xdp_type_name(req_hdr->type),
++						    req_hdr->type,
++						    pkg->frame.size,
++						    req->response_size / 4,
++						    req->response_size);
+ 			return false;
++		}
+ 
+ 		/* Make sure route matches */
+ 		if ((res_hdr->xd_hdr.route_hi & ~BIT(31)) !=
+-		     req_hdr->xd_hdr.route_hi)
++		     req_hdr->xd_hdr.route_hi) {
++			if (xdomain_debug)
++				pr_info_ratelimited("thunderbolt xdomain: match drop route_hi req_type=%s(%#x) res_type=%s(%#x) req_route=%llx res_route=%llx req_seq=%u res_seq=%u frame_size=%u\n",
++						    tb_xdp_type_name(req_hdr->type),
++						    req_hdr->type,
++						    tb_xdp_type_name(res_hdr->type),
++						    res_hdr->type,
++						    tb_xdp_route(req_hdr),
++						    tb_xdp_route(res_hdr),
++						    tb_xdp_sequence(req_hdr),
++						    tb_xdp_sequence(res_hdr),
++						    pkg->frame.size);
+ 			return false;
+-		if ((res_hdr->xd_hdr.route_lo) != req_hdr->xd_hdr.route_lo)
++		}
++		if ((res_hdr->xd_hdr.route_lo) != req_hdr->xd_hdr.route_lo) {
++			if (xdomain_debug)
++				pr_info_ratelimited("thunderbolt xdomain: match drop route_lo req_type=%s(%#x) res_type=%s(%#x) req_route=%llx res_route=%llx req_seq=%u res_seq=%u frame_size=%u\n",
++						    tb_xdp_type_name(req_hdr->type),
++						    req_hdr->type,
++						    tb_xdp_type_name(res_hdr->type),
++						    res_hdr->type,
++						    tb_xdp_route(req_hdr),
++						    tb_xdp_route(res_hdr),
++						    tb_xdp_sequence(req_hdr),
++						    tb_xdp_sequence(res_hdr),
++						    pkg->frame.size);
+ 			return false;
++		}
+ 
+ 		/* Check that the XDomain protocol matches */
+-		if (!uuid_equal(&res_hdr->uuid, &req_hdr->uuid))
++		if (!uuid_equal(&res_hdr->uuid, &req_hdr->uuid)) {
++			if (xdomain_debug)
++				pr_info_ratelimited("thunderbolt xdomain: match drop protocol uuid req_type=%s(%#x) res_type=%s(%#x) route=%llx req_uuid=%pUb res_uuid=%pUb frame_size=%u\n",
++						    tb_xdp_type_name(req_hdr->type),
++						    req_hdr->type,
++						    tb_xdp_type_name(res_hdr->type),
++						    res_hdr->type,
++						    tb_xdp_route(req_hdr),
++						    &req_hdr->uuid,
++						    &res_hdr->uuid,
++						    pkg->frame.size);
+ 			return false;
++		}
++
++		if (xdomain_debug)
++			pr_info_ratelimited("thunderbolt xdomain: match accept req_type=%s(%#x) res_type=%s(%#x) route=%llx req_seq=%u res_seq=%u req_len=%u res_len=%u frame_size=%u response_size=%zu\n",
++					    tb_xdp_type_name(req_hdr->type),
++					    req_hdr->type,
++					    tb_xdp_type_name(res_hdr->type),
++					    res_hdr->type,
++					    tb_xdp_route(req_hdr),
++					    tb_xdp_sequence(req_hdr),
++					    tb_xdp_sequence(res_hdr),
++					    tb_xdp_length(req_hdr),
++					    tb_xdp_length(res_hdr),
++					    pkg->frame.size,
++					    req->response_size);
+ 
+ 		return true;
+ 	}
+@@ -278,21 +394,38 @@ static int tb_xdp_uuid_request(struct tb_ctl *ctl, u64 route, int retry,
+ 	memset(&req, 0, sizeof(req));
+ 	tb_xdp_fill_header(&req.hdr, route, retry % 4, UUID_REQUEST,
+ 			   sizeof(req));
++	if (xdomain_debug)
++		pr_info("thunderbolt xdomain: tx UUID request route=%llx seq=%u retry=%d\n",
++			route, tb_xdp_sequence(&req.hdr), retry);
+ 
+ 	memset(&res, 0, sizeof(res));
+ 	ret = __tb_xdomain_request(ctl, &req, sizeof(req),
+ 				   TB_CFG_PKG_XDOMAIN_REQ, &res, sizeof(res),
+ 				   TB_CFG_PKG_XDOMAIN_RESP,
+ 				   XDOMAIN_DEFAULT_TIMEOUT);
+-	if (ret)
++	if (ret) {
++		if (xdomain_debug)
++			pr_info("thunderbolt xdomain: UUID request route=%llx failed ret=%d\n",
++				route, ret);
+ 		return ret;
++	}
+ 
+ 	ret = tb_xdp_handle_error(&res.err);
+-	if (ret)
++	if (ret) {
++		if (xdomain_debug)
++			pr_info("thunderbolt xdomain: UUID response route=%llx error=%d type=%s(%#x) res_route=%llx seq=%u\n",
++				route, ret, tb_xdp_type_name(res.hdr.type),
++				res.hdr.type, tb_xdp_route(&res.hdr),
++				tb_xdp_sequence(&res.hdr));
+ 		return ret;
++	}
+ 
+ 	uuid_copy(uuid, &res.src_uuid);
+ 	*remote_route = (u64)res.src_route_hi << 32 | res.src_route_lo;
++	if (xdomain_debug)
++		pr_info("thunderbolt xdomain: rx UUID response req_route=%llx res_route=%llx remote_route=%llx seq=%u uuid=%pUb\n",
++			route, tb_xdp_route(&res.hdr), *remote_route,
++			tb_xdp_sequence(&res.hdr), uuid);
+ 
+ 	return 0;
+ }
+@@ -309,6 +442,9 @@ static int tb_xdp_uuid_response(struct tb_ctl *ctl, u64 route, u8 sequence,
+ 	uuid_copy(&res.src_uuid, uuid);
+ 	res.src_route_hi = upper_32_bits(route);
+ 	res.src_route_lo = lower_32_bits(route);
++	if (xdomain_debug)
++		pr_info("thunderbolt xdomain: tx UUID response route=%llx seq=%u uuid=%pUb\n",
++			route, sequence, uuid);
+ 
+ 	return __tb_xdomain_response(ctl, &res, sizeof(res),
+ 				     TB_CFG_PKG_XDOMAIN_RESP);
+@@ -323,6 +459,9 @@ static int tb_xdp_error_response(struct tb_ctl *ctl, u64 route, u8 sequence,
+ 	tb_xdp_fill_header(&res.hdr, route, sequence, ERROR_RESPONSE,
+ 			   sizeof(res));
+ 	res.error = error;
++	if (xdomain_debug)
++		pr_info("thunderbolt xdomain: tx error response route=%llx seq=%u error=%d\n",
++			route, sequence, error);
+ 
+ 	return __tb_xdomain_response(ctl, &res, sizeof(res),
+ 				     TB_CFG_PKG_XDOMAIN_RESP);
+@@ -353,16 +492,41 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 	data_len = 0;
+ 
+ 	do {
++		if (xdomain_debug)
++			pr_info("thunderbolt xdomain: tx properties request route=%llx seq=%u retry=%d offset=%u src=%pUb dst=%pUb\n",
++				route, tb_xdp_sequence(&req.hdr), retry,
++				req.offset, &req.src_uuid, &req.dst_uuid);
++
+ 		ret = __tb_xdomain_request(ctl, &req, sizeof(req),
+ 					   TB_CFG_PKG_XDOMAIN_REQ, res,
+ 					   total_size, TB_CFG_PKG_XDOMAIN_RESP,
+ 					   XDOMAIN_DEFAULT_TIMEOUT);
+-		if (ret)
++		if (ret) {
++			if (xdomain_debug)
++				pr_info("thunderbolt xdomain: properties request route=%llx offset=%u failed ret=%d\n",
++					route, req.offset, ret);
+ 			goto err;
++		}
++
++		if (xdomain_debug)
++			pr_info("thunderbolt xdomain: rx properties candidate req_route=%llx res_route=%llx req_seq=%u res_seq=%u type=%s(%#x) xdp_len=%u frame_src=%pUb frame_dst=%pUb offset=%u data_len=%u gen=%u\n",
++				route, tb_xdp_route(&res->hdr),
++				tb_xdp_sequence(&req.hdr),
++				tb_xdp_sequence(&res->hdr),
++				tb_xdp_type_name(res->hdr.type), res->hdr.type,
++				tb_xdp_length(&res->hdr), &res->src_uuid,
++				&res->dst_uuid, res->offset, res->data_length,
++				res->generation);
+ 
+ 		ret = tb_xdp_handle_error(&res->err);
+-		if (ret)
++		if (ret) {
++			if (xdomain_debug)
++				pr_info("thunderbolt xdomain: properties response route=%llx offset=%u protocol error ret=%d type=%s(%#x)\n",
++					route, req.offset, ret,
++					tb_xdp_type_name(res->hdr.type),
++					res->hdr.type);
+ 			goto err;
++		}
+ 
+ 		/*
+ 		 * Package length includes the whole payload without the
+@@ -372,6 +536,13 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 		len = res->hdr.xd_hdr.length_sn & TB_XDOMAIN_LENGTH_MASK;
+ 		if (len < sizeof(*res) / 4) {
+ 			ret = -EINVAL;
++			if (xdomain_debug)
++				pr_info("thunderbolt xdomain: properties response too short route=%llx offset=%u xdp_len=%u min=%zu type=%s(%#x) src=%pUb dst=%pUb\n",
++					route, req.offset, len,
++					sizeof(*res) / 4,
++					tb_xdp_type_name(res->hdr.type),
++					res->hdr.type, &res->src_uuid,
++					&res->dst_uuid);
+ 			goto err;
+ 		}
+ 
+@@ -380,6 +551,11 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 
+ 		if (res->offset != req.offset) {
+ 			ret = -EINVAL;
++			if (xdomain_debug)
++				pr_info("thunderbolt xdomain: properties response offset mismatch route=%llx req=%u res=%u chunk_len=%u data_len=%u src=%pUb dst=%pUb\n",
++					route, req.offset, res->offset, len,
++					res->data_length, &res->src_uuid,
++					&res->dst_uuid);
+ 			goto err;
+ 		}
+ 
+@@ -391,6 +567,11 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 			data_len = res->data_length;
+ 			if (data_len > TB_XDP_PROPERTIES_MAX_LENGTH) {
+ 				ret = -E2BIG;
++				if (xdomain_debug)
++					pr_info("thunderbolt xdomain: properties response too large route=%llx offset=%u chunk_len=%u data_len=%u max=%u src=%pUb dst=%pUb\n",
++						route, req.offset, len, data_len,
++						TB_XDP_PROPERTIES_MAX_LENGTH,
++						&res->src_uuid, &res->dst_uuid);
+ 				goto err;
+ 			}
+ 
+@@ -403,6 +584,13 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 
+ 		if (req.offset + len > data_len)
+ 			len = data_len - req.offset;
++
++		if (xdomain_debug)
++			pr_info("thunderbolt xdomain: accepted properties chunk route=%llx offset=%u chunk_len=%u data_len=%u next_offset=%u gen=%u src=%pUb dst=%pUb\n",
++				route, req.offset, len, data_len,
++				req.offset + len, res->generation,
++				&res->src_uuid, &res->dst_uuid);
++
+ 		memcpy(data + req.offset, res->data, len * 4);
+ 		req.offset += len;
+ 	} while (!data_len || req.offset < data_len);
+@@ -429,12 +617,24 @@ static int tb_xdp_properties_response(struct tb *tb, struct tb_ctl *ctl,
+ 	u16 len;
+ 	int ret;
+ 
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain rx properties request packet_route=%llx xd_route=%llx state=%s seq=%u offset=%u src=%pUb dst=%pUb local=%pUb remote=%pUb\n",
++			 tb_xdp_route(&req->hdr), xd->route,
++			 state_names[xd->state], sequence, req->offset,
++			 &req->src_uuid, &req->dst_uuid, xd->local_uuid,
++			 xd->remote_uuid);
++
+ 	/*
+ 	 * Currently we expect all requests to be directed to us. The
+ 	 * protocol supports forwarding, though which we might add
+ 	 * support later on.
+ 	 */
+ 	if (!uuid_equal(xd->local_uuid, &req->dst_uuid)) {
++		if (xdomain_debug)
++			dev_info(&xd->dev, "XDomain properties request unknown domain packet_route=%llx xd_route=%llx seq=%u offset=%u src=%pUb dst=%pUb local=%pUb remote=%pUb\n",
++				 tb_xdp_route(&req->hdr), xd->route, sequence,
++				 req->offset, &req->src_uuid, &req->dst_uuid,
++				 xd->local_uuid, xd->remote_uuid);
+ 		tb_xdp_error_response(ctl, xd->route, sequence,
+ 				      ERROR_UNKNOWN_DOMAIN);
+ 		return 0;
+@@ -443,6 +643,11 @@ static int tb_xdp_properties_response(struct tb *tb, struct tb_ctl *ctl,
+ 	mutex_lock(&xd->lock);
+ 
+ 	if (req->offset >= xd->local_property_block_len) {
++		if (xdomain_debug)
++			dev_info(&xd->dev, "XDomain properties request bad offset packet_route=%llx xd_route=%llx seq=%u offset=%u block_len=%u src=%pUb dst=%pUb\n",
++				 tb_xdp_route(&req->hdr), xd->route, sequence,
++				 req->offset, xd->local_property_block_len,
++				 &req->src_uuid, &req->dst_uuid);
+ 		mutex_unlock(&xd->lock);
+ 		return -EINVAL;
+ 	}
+@@ -466,6 +671,12 @@ static int tb_xdp_properties_response(struct tb *tb, struct tb_ctl *ctl,
+ 	uuid_copy(&res->dst_uuid, &req->src_uuid);
+ 	memcpy(res->data, &xd->local_property_block[req->offset], len * 4);
+ 
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain tx properties response route=%llx seq=%u offset=%u chunk_len=%u block_len=%u gen=%u src=%pUb dst=%pUb\n",
++			 xd->route, sequence, res->offset, len,
++			 res->data_length, res->generation, &res->src_uuid,
++			 &res->dst_uuid);
++
+ 	mutex_unlock(&xd->lock);
+ 
+ 	ret = __tb_xdomain_response(ctl, res, total_size,
+@@ -727,6 +938,11 @@ static void update_property_block(struct tb_xdomain *xd)
+ 		xd->local_property_block = block;
+ 		xd->local_property_block_len = block_len;
+ 		xd->local_property_block_gen = xdomain_property_block_gen;
++		if (xdomain_debug)
++			dev_info(&xd->dev, "XDomain local properties rebuilt route=%llx block_len=%d gen=%u max_hopid=%u\n",
++				 xd->route, block_len,
++				 xd->local_property_block_gen,
++				 xd->local_max_hopid);
+ 	}
+ 
+ out_unlock:
+@@ -737,6 +953,10 @@ static void update_property_block(struct tb_xdomain *xd)
+ static void start_handshake(struct tb_xdomain *xd)
+ {
+ 	xd->state = XDOMAIN_STATE_INIT;
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain start handshake route=%llx local=%pUb remote=%pUb needs_uuid=%d\n",
++			 xd->route, xd->local_uuid, xd->remote_uuid,
++			 xd->needs_uuid);
+ 	queue_delayed_work(xd->tb->wq, &xd->state_work,
+ 			   msecs_to_jiffies(XDOMAIN_SHORT_TIMEOUT));
+ }
+@@ -751,6 +971,10 @@ static void __stop_handshake(struct tb_xdomain *xd)
+ 
+ static void stop_handshake(struct tb_xdomain *xd)
+ {
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain stop handshake route=%llx state=%s local=%pUb remote=%pUb\n",
++			 xd->route, state_names[xd->state], xd->local_uuid,
++			 xd->remote_uuid);
+ 	cancel_delayed_work_sync(&xd->state_work);
+ 	__stop_handshake(xd);
+ }
+@@ -789,6 +1013,20 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 	if (xd)
+ 		update_property_block(xd);
+ 
++	if (xdomain_debug) {
++		if (xd) {
++			dev_info(&xd->dev, "XDomain dispatch request type=%s(%#x) packet_route=%llx xd_route=%llx state=%s seq=%u xdp_len=%u local=%pUb remote=%pUb\n",
++				 tb_xdp_type_name(pkg->type), pkg->type, route,
++				 xd->route, state_names[xd->state], sequence,
++				 tb_xdp_length(pkg), xd->local_uuid,
++				 xd->remote_uuid);
++		} else {
++			pr_info("thunderbolt xdomain: dispatch request with no route match type=%s(%#x) packet_route=%llx seq=%u xdp_len=%u local=%pUb\n",
++				tb_xdp_type_name(pkg->type), pkg->type, route,
++				sequence, tb_xdp_length(pkg), uuid);
++		}
++	}
++
+ 	switch (pkg->type) {
+ 	case PROPERTIES_REQUEST:
+ 		tb_dbg(tb, "%llx: received XDomain properties request\n", route);
+@@ -1354,10 +1592,17 @@ static int tb_xdomain_get_uuid(struct tb_xdomain *xd)
+ 	int ret;
+ 
+ 	dev_dbg(&xd->dev, "requesting remote UUID\n");
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain state UUID route=%llx retries=%d local=%pUb current_remote=%pUb\n",
++			 xd->route, xd->state_retries, xd->local_uuid,
++			 xd->remote_uuid);
+ 
+ 	ret = tb_xdp_uuid_request(tb->ctl, xd->route, xd->state_retries, &uuid,
+ 				  &route);
+ 	if (ret < 0) {
++		if (xdomain_debug)
++			dev_info(&xd->dev, "XDomain UUID request failed route=%llx ret=%d retries_left=%d\n",
++				 xd->route, ret, xd->state_retries);
+ 		if (xd->state_retries-- > 0) {
+ 			dev_dbg(&xd->dev, "failed to request UUID, retrying\n");
+ 			return -EAGAIN;
+@@ -1367,6 +1612,10 @@ static int tb_xdomain_get_uuid(struct tb_xdomain *xd)
+ 	}
+ 
+ 	dev_dbg(&xd->dev, "got remote UUID %pUb\n", &uuid);
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain UUID result route=%llx remote_route=%llx uuid=%pUb local=%pUb previous_remote=%pUb\n",
++			 xd->route, route, &uuid, xd->local_uuid,
++			 xd->remote_uuid);
+ 
+ 	if (uuid_equal(&uuid, xd->local_uuid)) {
+ 		if (route == xd->route)
+@@ -1543,11 +1792,19 @@ static int tb_xdomain_get_properties(struct tb_xdomain *xd)
+ 	int ret;
+ 
+ 	dev_dbg(&xd->dev, "requesting remote properties\n");
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain state PROPERTIES route=%llx retries=%d local=%pUb remote=%pUb\n",
++			 xd->route, xd->state_retries, xd->local_uuid,
++			 xd->remote_uuid);
+ 
+ 	ret = tb_xdp_properties_request(tb->ctl, xd->route, xd->local_uuid,
+ 					xd->remote_uuid, xd->state_retries,
+ 					&block, &gen);
+ 	if (ret < 0) {
++		if (xdomain_debug)
++			dev_info(&xd->dev, "XDomain properties request failed route=%llx ret=%d retries_left=%d remote=%pUb\n",
++				 xd->route, ret, xd->state_retries,
++				 xd->remote_uuid);
+ 		if (xd->state_retries-- > 0) {
+ 			dev_dbg(&xd->dev,
+ 				"failed to request remote properties, retrying\n");
+@@ -1559,6 +1816,9 @@ static int tb_xdomain_get_properties(struct tb_xdomain *xd)
+ 
+ 		return ret;
+ 	}
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain properties result route=%llx block_len=%d gen=%u remote=%pUb\n",
++			 xd->route, ret, gen, xd->remote_uuid);
+ 
+ 	mutex_lock(&xd->lock);
+ 
+@@ -2171,6 +2431,11 @@ struct tb_xdomain *tb_xdomain_alloc(struct tb *tb, struct device *parent,
+ 	dev_dbg(&xd->dev, "local UUID %pUb\n", local_uuid);
+ 	if (remote_uuid)
+ 		dev_dbg(&xd->dev, "remote UUID %pUb\n", remote_uuid);
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain allocated route=%llx parent=%s local=%pUb remote=%pUb needs_uuid=%d max_hopid=%u\n",
++			 route, dev_name(parent), xd->local_uuid,
++			 xd->remote_uuid, xd->needs_uuid,
++			 xd->local_max_hopid);
+ 
+ 	/*
+ 	 * This keeps the DMA powered on as long as we have active
+@@ -2201,6 +2466,11 @@ struct tb_xdomain *tb_xdomain_alloc(struct tb *tb, struct device *parent,
+  */
+ void tb_xdomain_add(struct tb_xdomain *xd)
+ {
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain add route=%llx link=%u depth=%u local=%pUb remote=%pUb needs_uuid=%d\n",
++			 xd->route, xd->link, xd->depth, xd->local_uuid,
++			 xd->remote_uuid, xd->needs_uuid);
++
+ 	/* Start exchanging properties with the other host */
+ 	start_handshake(xd);
+ }
+@@ -2223,6 +2493,12 @@ static int unregister_service(struct device *dev, void *data)
+  */
+ void tb_xdomain_remove(struct tb_xdomain *xd)
+ {
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain remove route=%llx link=%u depth=%u state=%s local=%pUb remote=%pUb registered=%d unplugged=%d\n",
++			 xd->route, xd->link, xd->depth, state_names[xd->state],
++			 xd->local_uuid, xd->remote_uuid,
++			 device_is_registered(&xd->dev), xd->is_unplugged);
++
+ 	tb_xdomain_debugfs_remove(xd);
+ 
+ 	mutex_lock(&xd->lock);
+@@ -2258,6 +2534,11 @@ void tb_xdomain_unregister(struct tb_xdomain *xd)
+ {
+ 	lockdep_assert_not_held(&xd->tb->lock);
+ 
++	if (xdomain_debug)
++		dev_info(&xd->dev, "XDomain unregister route=%llx link=%u depth=%u state=%s local=%pUb remote=%pUb\n",
++			 xd->route, xd->link, xd->depth, state_names[xd->state],
++			 xd->local_uuid, xd->remote_uuid);
++
+ 	device_for_each_child_reverse(&xd->dev, xd, unregister_service);
+ 
+ 	dev_info(&xd->dev, "host disconnected\n");
+-- 
+2.54.0
+

--- a/kernel-workflow/patches/0010-thunderbolt-xdomain-drain-protocol-callbacks-on-unr.patch
+++ b/kernel-workflow/patches/0010-thunderbolt-xdomain-drain-protocol-callbacks-on-unr.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: georgewhewell <georgerw@gmail.com>
+Date: Mon, 8 Jun 2026 00:00:00 +0000
+Subject: [PATCH] thunderbolt: xdomain: drain protocol callbacks on unregister
+
+tb_unregister_protocol_handler() removes the handler from the dispatch list,
+but before this change it could return while a protocol dispatch that selected
+that handler was still running.  The dispatcher also drops xdomain_lock while
+calling a handler, so a concurrent unregister can remove another handler that
+the in-flight list walk has already saved as its next pointer.
+
+Module owner pinning protects callback text.  It does not protect dynamically
+allocated handler objects or handler->data.
+
+Track active XDomain protocol dispatches and wait for them to drain after
+removing a handler from the list.  After tb_unregister_protocol_handler()
+returns, the caller can free handler-owned callback data without a separate
+delay or driver-private grace period.
+
+Signed-off-by: georgewhewell <georgerw@gmail.com>
+---
+ drivers/thunderbolt/xdomain.c | 15 +++++++++++++++
+ include/linux/thunderbolt.h   |  1 +
+ 2 files changed, 16 insertions(+)
+
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+index ccc04a2..09a0ef4 100644
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -7,6 +7,7 @@
+  *          Mika Westerberg <mika.westerberg@linux.intel.com>
+  */
+ 
++#include <linux/atomic.h>
+ #include <linux/device.h>
+ #include <linux/delay.h>
+ #include <linux/kmod.h>
+@@ -17,6 +18,7 @@
+ #include <linux/string_helpers.h>
+ #include <linux/utsname.h>
+ #include <linux/uuid.h>
++#include <linux/wait.h>
+ #include <linux/workqueue.h>
+ 
+ #include "tb.h"
+@@ -76,6 +78,8 @@ static u32 xdomain_property_block_gen;
+ 
+ /* Additional protocol handlers */
+ static LIST_HEAD(protocol_handlers);
++static atomic_t protocol_dispatch_active = ATOMIC_INIT(0);
++static DECLARE_WAIT_QUEUE_HEAD(protocol_dispatch_wait);
+ 
+ /* UUID for XDomain discovery protocol: b638d70e-42ff-40bb-97c2-90e2c0b2ff07 */
+ static const uuid_t tb_xdp_uuid =
+@@ -701,6 +705,8 @@ void tb_unregister_protocol_handler(struct tb_protocol_handler *handler)
+ 	mutex_lock(&xdomain_lock);
+ 	list_del_init(&handler->list);
+ 	mutex_unlock(&xdomain_lock);
++	wait_event(protocol_dispatch_wait,
++		   !atomic_read(&protocol_dispatch_active));
+ }
+ EXPORT_SYMBOL_GPL(tb_unregister_protocol_handler);
+ 
+@@ -2702,6 +2708,7 @@ bool tb_xdomain_handle_request(struct tb *tb, enum tb_cfg_pkg_type type,
+ 	route = ((u64)hdr->xd_hdr.route_hi << 32 | hdr->xd_hdr.route_lo) &
+ 		~BIT_ULL(63);
+ 	source_xd = tb_xdomain_find_by_route_locked(tb, route);
++	atomic_inc(&protocol_dispatch_active);
+ 
+ 	mutex_lock(&xdomain_lock);
+ 	list_for_each_entry_safe(handler, tmp, &protocol_handlers, list) {
+@@ -2731,6 +2738,9 @@ bool tb_xdomain_handle_request(struct tb *tb, enum tb_cfg_pkg_type type,
+ 	}
+ 	mutex_unlock(&xdomain_lock);
+ 
++	if (atomic_dec_and_test(&protocol_dispatch_active))
++		wake_up_all(&protocol_dispatch_wait);
++
+ 	if (!matched) {
+ 		const u32 *w = buf;
+ 		size_t n = size / 4;
+diff --git a/include/linux/thunderbolt.h b/include/linux/thunderbolt.h
+index 4698440..40cb20e 100644
+--- a/include/linux/thunderbolt.h
++++ b/include/linux/thunderbolt.h
+@@ -385,5 +385,6 @@ int tb_xdomain_request(struct tb_xdomain *xd, const void *request,
+ #define TB_PROTOCOL_HANDLER_HAS_XDOMAIN 1
+ #define TB_PROTOCOL_HANDLER_HAS_OWNER 1
++#define TB_PROTOCOL_HANDLER_UNREGISTER_DRAINS 1
+ struct module;
+ struct tb_protocol_handler {
+ 	const uuid_t *uuid;
+-- 
+2.54.0

--- a/kernel-workflow/patches/0122-thunderbolt-xdomain-property-fixes.patch
+++ b/kernel-workflow/patches/0122-thunderbolt-xdomain-property-fixes.patch
@@ -1,0 +1,223 @@
+From e0abb380927d767d76163c942deee323935e883c Mon Sep 17 00:00:00 2001
+From: georgewhewell <georgerw@gmail.com>
+Date: Sat, 6 Jun 2026 15:30:17 +0200
+Subject: [PATCH] thunderbolt: backport XDomain property hardening fixes
+
+Backport the accepted Westeri fixes onto the thunderbolt-ibverbs portable patch base after the USB4STREAM/property-merge local stack:
+
+  01deda015206 thunderbolt: property: Reject u32 wrap in tb_property_entry_valid()
+
+  de21b59c29e3 thunderbolt: property: Reject dir_len < 4 to prevent size_t underflow
+
+  928abe19fbf0 thunderbolt: property: Cap recursion depth in __tb_property_parse_dir()
+
+  cff8eb65d1ea thunderbolt: Reject zero-length property entries in validator
+
+  65423079c742 thunderbolt: Bound root directory content to block size
+
+  322e93448d90 thunderbolt: Clamp XDomain response data copy to allocation size
+
+  a504b9f2797b thunderbolt: Validate XDomain request packet size before type cast
+
+  4db2bd2ed478 thunderbolt: Limit XDomain response copy to actual frame size
+
+These fixes are carried as one rebased patch because the raw maintainer-tree mbox conflicts with the local property merge and USB4STREAM patch stack.
+---
+ drivers/thunderbolt/property.c | 38 ++++++++++++++++++++++++++--------
+ drivers/thunderbolt/xdomain.c  | 14 ++++++++++---
+ 2 files changed, 40 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/thunderbolt/property.c b/drivers/thunderbolt/property.c
+index 6b9666b61..df18a6d69 100644
+--- a/drivers/thunderbolt/property.c
++++ b/drivers/thunderbolt/property.c
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <linux/err.h>
++#include <linux/overflow.h>
+ #include <linux/slab.h>
+ #include <linux/string.h>
+ #include <linux/uuid.h>
+@@ -34,10 +35,11 @@ struct tb_property_dir_entry {
+ };
+ 
+ #define TB_PROPERTY_ROOTDIR_MAGIC	0x55584401
++#define TB_PROPERTY_MAX_DEPTH		8
+ 
+ static struct tb_property_dir *__tb_property_parse_dir(const u32 *block,
+ 	size_t block_len, unsigned int dir_offset, size_t dir_len,
+-	bool is_root);
++	bool is_root, unsigned int depth);
+ static struct tb_property *tb_property_copy(const struct tb_property *property);
+ 
+ static inline void parse_dwdata(void *dst, const void *src, size_t dwords)
+@@ -53,13 +55,18 @@ static inline void format_dwdata(void *dst, const void *src, size_t dwords)
+ static bool tb_property_entry_valid(const struct tb_property_entry *entry,
+ 				  size_t block_len)
+ {
++	u32 end;
++
+ 	switch (entry->type) {
+ 	case TB_PROPERTY_TYPE_DIRECTORY:
+ 	case TB_PROPERTY_TYPE_DATA:
+ 	case TB_PROPERTY_TYPE_TEXT:
++		if (!entry->length)
++			return false;
+ 		if (entry->length > block_len)
+ 			return false;
+-		if (entry->value + entry->length > block_len)
++		if (check_add_overflow(entry->value, entry->length, &end) ||
++		    end > block_len)
+ 			return false;
+ 		break;
+ 
+@@ -94,7 +101,8 @@ tb_property_alloc(const char *key, enum tb_property_type type)
+ }
+ 
+ static struct tb_property *tb_property_parse(const u32 *block, size_t block_len,
+-					const struct tb_property_entry *entry)
++					const struct tb_property_entry *entry,
++					unsigned int depth)
+ {
+ 	char key[TB_PROPERTY_KEY_SIZE + 1];
+ 	struct tb_property *property;
+@@ -115,7 +123,7 @@ static struct tb_property *tb_property_parse(const u32 *block, size_t block_len,
+ 	switch (property->type) {
+ 	case TB_PROPERTY_TYPE_DIRECTORY:
+ 		dir = __tb_property_parse_dir(block, block_len, entry->value,
+-					      entry->length, false);
++					      entry->length, false, depth + 1);
+ 		if (!dir) {
+ 			kfree(property);
+ 			return NULL;
+@@ -160,21 +168,35 @@ static struct tb_property *tb_property_parse(const u32 *block, size_t block_len,
+ }
+ 
+ static struct tb_property_dir *__tb_property_parse_dir(const u32 *block,
+-	size_t block_len, unsigned int dir_offset, size_t dir_len, bool is_root)
++	size_t block_len, unsigned int dir_offset, size_t dir_len, bool is_root,
++	unsigned int depth)
+ {
+ 	const struct tb_property_entry *entries;
+ 	size_t i, content_len, nentries;
+ 	unsigned int content_offset;
+ 	struct tb_property_dir *dir;
+ 
++	if (depth > TB_PROPERTY_MAX_DEPTH)
++		return NULL;
++
+ 	dir = kzalloc_obj(*dir);
+ 	if (!dir)
+ 		return NULL;
+ 
++	INIT_LIST_HEAD(&dir->properties);
++
+ 	if (is_root) {
+ 		content_offset = dir_offset + 2;
+ 		content_len = dir_len;
++		if (content_offset + content_len > block_len) {
++			tb_property_free_dir(dir);
++			return NULL;
++		}
+ 	} else {
++		if (dir_len < 4) {
++			tb_property_free_dir(dir);
++			return NULL;
++		}
+ 		dir->uuid = kmemdup(&block[dir_offset], sizeof(*dir->uuid),
+ 				    GFP_KERNEL);
+ 		if (!dir->uuid) {
+@@ -188,12 +210,10 @@ static struct tb_property_dir *__tb_property_parse_dir(const u32 *block,
+ 	entries = (const struct tb_property_entry *)&block[content_offset];
+ 	nentries = content_len / (sizeof(*entries) / 4);
+ 
+-	INIT_LIST_HEAD(&dir->properties);
+-
+ 	for (i = 0; i < nentries; i++) {
+ 		struct tb_property *property;
+ 
+-		property = tb_property_parse(block, block_len, &entries[i]);
++		property = tb_property_parse(block, block_len, &entries[i], depth);
+ 		if (!property) {
+ 			tb_property_free_dir(dir);
+ 			return NULL;
+@@ -232,7 +252,7 @@ struct tb_property_dir *tb_property_parse_dir(const u32 *block,
+ 		return NULL;
+ 
+ 	return __tb_property_parse_dir(block, block_len, 0, rootdir->length,
+-				       true);
++				       true, 0);
+ }
+ 
+ /**
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+index d45f03207..395c7cd12 100644
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -55,6 +55,7 @@ static const char * const state_names[] = {
+ struct xdomain_request_work {
+ 	struct work_struct work;
+ 	struct tb_xdp_header *pkg;
++	size_t pkg_len;
+ 	struct tb *tb;
+ };
+ 
+@@ -122,7 +123,9 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ static bool tb_xdomain_copy(struct tb_cfg_request *req,
+ 			    const struct ctl_pkg *pkg)
+ {
+-	memcpy(req->response, pkg->buffer, req->response_size);
++	size_t len = min_t(size_t, pkg->frame.size, req->response_size);
++
++	memcpy(req->response, pkg->buffer, len);
+ 	req->result.err = 0;
+ 	return true;
+ }
+@@ -398,6 +401,8 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+ 			}
+ 		}
+ 
++		if (req.offset + len > data_len)
++			len = data_len - req.offset;
+ 		memcpy(data + req.offset, res->data, len * 4);
+ 		req.offset += len;
+ 	} while (!data_len || req.offset < data_len);
+@@ -755,6 +760,7 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 	struct xdomain_request_work *xw = container_of(work, typeof(*xw), work);
+ 	const struct tb_xdp_header *pkg = xw->pkg;
+ 	const struct tb_xdomain_header *xhdr = &pkg->xd_hdr;
++	size_t pkg_len = xw->pkg_len;
+ 	struct tb *tb = xw->tb;
+ 	struct tb_ctl *ctl = tb->ctl;
+ 	struct tb_xdomain *xd;
+@@ -786,7 +792,7 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 	switch (pkg->type) {
+ 	case PROPERTIES_REQUEST:
+ 		tb_dbg(tb, "%llx: received XDomain properties request\n", route);
+-		if (xd) {
++		if (xd && pkg_len >= sizeof(struct tb_xdp_properties)) {
+ 			ret = tb_xdp_properties_response(tb, ctl, xd, sequence,
+ 				(const struct tb_xdp_properties *)pkg);
+ 		}
+@@ -879,7 +885,8 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 		tb_dbg(tb, "%llx: received XDomain link state change request\n",
+ 		       route);
+ 
+-		if (xd && xd->state == XDOMAIN_STATE_BONDING_UUID_HIGH) {
++		if (xd && xd->state == XDOMAIN_STATE_BONDING_UUID_HIGH &&
++		    pkg_len >= sizeof(struct tb_xdp_link_state_change)) {
+ 			const struct tb_xdp_link_state_change *lsc =
+ 				(const struct tb_xdp_link_state_change *)pkg;
+ 
+@@ -932,6 +939,7 @@ tb_xdp_schedule_request(struct tb *tb, const struct tb_xdp_header *hdr,
+ 		kfree(xw);
+ 		return false;
+ 	}
++	xw->pkg_len = size;
+ 	xw->tb = tb_domain_get(tb);
+ 
+ 	schedule_work(&xw->work);
+-- 
+2.54.0
+

--- a/kernel-workflow/patches/0123-thunderbolt-Prevent-XDomain-delayed-work-use-after.patch
+++ b/kernel-workflow/patches/0123-thunderbolt-Prevent-XDomain-delayed-work-use-after.patch
@@ -1,0 +1,145 @@
+From 2c5d2d3c3f70cde2565d7b279b544893a2035842 Mon Sep 17 00:00:00 2001
+From: Michael Bommarito <michael.bommarito@gmail.com>
+Date: Wed, 27 May 2026 07:46:04 -0400
+Subject: [PATCH] thunderbolt: Prevent XDomain delayed work use-after-free on
+ disconnect
+
+tb_xdp_handle_request() runs on system_wq and queues
+xd->state_work via queue_delayed_work() in three request handlers:
+PROPERTIES_CHANGED_REQUEST, UUID_REQUEST (via start_handshake),
+and LINK_STATE_CHANGE_REQUEST.  Similarly, update_xdomain() queues
+xd->properties_changed_work when local properties change.
+
+Concurrently, tb_xdomain_remove() calls stop_handshake() which does
+cancel_delayed_work_sync() on both delayed works.  Later,
+tb_xdomain_unregister() calls device_unregister() which eventually
+frees the xdomain.  Since commit 559c1e1e0134 ("thunderbolt: Run
+tb_xdp_handle_request() in system workqueue") moved the request
+handler off tb->wq, the handler and the remove path are no longer
+serialized.  If queue_delayed_work() executes after
+cancel_delayed_work_sync() but before the xdomain is freed, the
+delayed work fires on a freed object.
+
+Add xd->removing that tb_xdomain_remove() sets under xd->lock
+before calling stop_handshake().  Each external queue site holds
+the same lock and checks removing before calling
+queue_delayed_work().  This provides the mutual exclusion needed:
+either the queue site acquires the lock first and queues work that
+the subsequent cancel will see, or the remove path acquires the
+lock first and the queue site observes removing == true and skips
+the queue.
+
+Fixes: 559c1e1e0134 ("thunderbolt: Run tb_xdp_handle_request() in system workqueue")
+Cc: stable@vger.kernel.org
+Assisted-by: Claude:claude-opus-4-7
+Signed-off-by: Michael Bommarito <michael.bommarito@gmail.com>
+Signed-off-by: Mika Westerberg <mika.westerberg@linux.intel.com>
+---
+ drivers/thunderbolt/xdomain.c | 41 ++++++++++++++++++++++++++---------
+ include/linux/thunderbolt.h   |  3 +++
+ 2 files changed, 34 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+index 781d88d06b93..fe6c5ac703f4 100644
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -803,9 +803,13 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 		 * the xdomain related to this connection as well in
+ 		 * case there is a change in services it offers.
+ 		 */
+-		if (xd && device_is_registered(&xd->dev))
+-			queue_delayed_work(tb->wq, &xd->state_work,
+-					   msecs_to_jiffies(XDOMAIN_SHORT_TIMEOUT));
++		if (xd) {
++			mutex_lock(&xd->lock);
++			if (!xd->removing && device_is_registered(&xd->dev))
++				queue_delayed_work(tb->wq, &xd->state_work,
++						   msecs_to_jiffies(XDOMAIN_SHORT_TIMEOUT));
++			mutex_unlock(&xd->lock);
++		}
+ 		break;
+ 
+ 	case UUID_REQUEST_OLD:
+@@ -818,8 +822,12 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 		 * received UUID request from the remote host.
+ 		 */
+ 		if (!ret && xd && xd->state == XDOMAIN_STATE_ERROR) {
+-			dev_dbg(&xd->dev, "restarting handshake\n");
+-			start_handshake(xd);
++			mutex_lock(&xd->lock);
++			if (!xd->removing) {
++				dev_dbg(&xd->dev, "restarting handshake\n");
++				start_handshake(xd);
++			}
++			mutex_unlock(&xd->lock);
+ 		}
+ 		break;
+ 
+@@ -885,9 +893,13 @@ static void tb_xdp_handle_request(struct work_struct *work)
+ 
+ 			ret = tb_xdp_link_state_change_response(ctl, route,
+ 								sequence, 0);
+-			xd->target_link_width = lsc->tlw;
+-			queue_delayed_work(tb->wq, &xd->state_work,
+-					   msecs_to_jiffies(XDOMAIN_SHORT_TIMEOUT));
++			mutex_lock(&xd->lock);
++			if (!xd->removing) {
++				xd->target_link_width = lsc->tlw;
++				queue_delayed_work(tb->wq, &xd->state_work,
++						   msecs_to_jiffies(XDOMAIN_SHORT_TIMEOUT));
++			}
++			mutex_unlock(&xd->lock);
+ 		} else {
+ 			tb_xdp_error_response(ctl, route, sequence,
+ 					      ERROR_NOT_READY);
+@@ -971,8 +983,12 @@ static int update_xdomain(struct device *dev, void *data)
+ 
+ 	xd = tb_to_xdomain(dev);
+ 	if (xd) {
+-		queue_delayed_work(xd->tb->wq, &xd->properties_changed_work,
+-				   msecs_to_jiffies(50));
++		mutex_lock(&xd->lock);
++		if (!xd->removing)
++			queue_delayed_work(xd->tb->wq,
++					   &xd->properties_changed_work,
++					   msecs_to_jiffies(50));
++		mutex_unlock(&xd->lock);
+ 	}
+ 
+ 	return 0;
+@@ -2200,6 +2216,11 @@ static int unregister_service(struct device *dev, void *data)
+ void tb_xdomain_remove(struct tb_xdomain *xd)
+ {
+ 	tb_xdomain_debugfs_remove(xd);
++
++	mutex_lock(&xd->lock);
++	xd->removing = true;
++	mutex_unlock(&xd->lock);
++
+ 	stop_handshake(xd);
+ 	tb_xdomain_link_exit(xd);
+ 
+diff --git a/include/linux/thunderbolt.h b/include/linux/thunderbolt.h
+index b5659f883517..feb1af175cfd 100644
+--- a/include/linux/thunderbolt.h
++++ b/include/linux/thunderbolt.h
+@@ -213,6 +213,8 @@ enum tb_link_width {
+  * @link_width: Width of the downstream facing link
+  * @link_usb4: Downstream link is USB4
+  * @is_unplugged: The XDomain is unplugged
++ * @removing: Set by tb_xdomain_remove() under @lock to prevent
++ *	      concurrent delayed work queueing
+  * @needs_uuid: If the XDomain does not have @remote_uuid it will be
+  *		queried first
+  * @service_ids: Used to generate IDs for the services
+@@ -262,6 +264,7 @@ struct tb_xdomain {
+ 	enum tb_link_width link_width;
+ 	bool link_usb4;
+ 	bool is_unplugged;
++	bool removing;
+ 	bool needs_uuid;
+ 	struct ida service_ids;
+ 	struct ida in_hopids;
+-- 
+2.54.0
+

--- a/kernel-workflow/patches/local-portable.nix
+++ b/kernel-workflow/patches/local-portable.nix
@@ -2,3 +2,21 @@ let
   debugNames = map (patch: patch.name) (import ./local-integration-debug.nix);
 in
 builtins.filter (patch: !(builtins.elem patch.name debugNames)) (import ./local.nix)
+++ [
+  {
+    name = "usb4-xdomain-property-fixes";
+    patch = ./0122-thunderbolt-xdomain-property-fixes.patch;
+  }
+  {
+    name = "usb4-xdomain-delayed-work-uaf";
+    patch = ./0123-thunderbolt-Prevent-XDomain-delayed-work-use-after.patch;
+  }
+  {
+    name = "usb4-xdomain-lane-bonding-module-param";
+    patch = ./0009-thunderbolt-xdomain-lane-bonding-module-param.patch;
+  }
+  {
+    name = "usb4-xdomain-route-trace";
+    patch = ./0010-thunderbolt-trace-XDomain-route-matching.patch;
+  }
+]

--- a/kernel-workflow/patches/local.nix
+++ b/kernel-workflow/patches/local.nix
@@ -22,4 +22,12 @@
     name = "usb4-xdomain-pin-protocol-handler-owner";
     patch = ./0008-thunderbolt-xdomain-pin-protocol-handler-owner.patch;
   }
+  {
+    name = "usb4-xdomain-property-identity-match";
+    patch = ./0009-thunderbolt-xdomain-match-properties-by-identity.patch;
+  }
+  {
+    name = "usb4-xdomain-drain-protocol-callbacks";
+    patch = ./0010-thunderbolt-xdomain-drain-protocol-callbacks-on-unr.patch;
+  }
 ]

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -38,7 +38,6 @@ help:
 	@echo "  tbnet_identity=auto|stock|stock_proxy|minimal_packet|off"
 	@echo "  tbnet_identity_tbnet=<netdev>"
 	@echo "  tbnet_identity_gid=auto|<netdev>"
-	@echo "  tbnet_identity_minimal_e2e=0|1"
 	@echo "  tbnet_identity_minimal_apple_only=0|1"
 	@echo "  bind_services=0|1"
 	@echo "  allocate_rings=0|1"

--- a/kernel/debugfs.c
+++ b/kernel/debugfs.c
@@ -105,10 +105,10 @@ static int tbv_debugfs_summary_show(struct seq_file *s, void *unused)
 	seq_printf(s, "start_rings: %u\n", state->start_rings);
 	seq_printf(s, "negotiate_native: %u\n", state->negotiate_native);
 	seq_printf(s, "enable_tunnels: %u\n", state->enable_tunnels);
-	seq_printf(s, "apple_tunnels_wait_tbnet: %u\n",
-		   state->apple_tunnels_wait_tbnet);
-	seq_printf(s, "apple_tunnels_pending: %u\n",
-		   state->apple_tunnels_pending);
+	seq_printf(s, "apple_rails_wait_tbnet: %u\n",
+		   state->apple_rails_wait_tbnet);
+	seq_printf(s, "apple_rails_pending: %u\n",
+		   state->apple_rails_pending);
 	seq_printf(s, "native_data: %u\n", state->native_data);
 	seq_printf(s, "apple_data: %u\n", state->apple_data);
 	seq_printf(s, "native_fragment_striping: %u\n",
@@ -193,6 +193,8 @@ static int tbv_debugfs_summary_show(struct seq_file *s, void *unused)
 		   atomic64_read(&state->data_tx_credit_received));
 	seq_printf(s, "data_rx_completed: %lld\n",
 		   atomic64_read(&state->data_rx_completed));
+	seq_printf(s, "data_rx_canceled: %lld\n",
+		   atomic64_read(&state->data_rx_canceled));
 	seq_printf(s, "data_rx_credit_sent: %lld\n",
 		   atomic64_read(&state->data_rx_credit_sent));
 	seq_printf(s, "data_rx_credit_send_error: %lld\n",
@@ -203,6 +205,24 @@ static int tbv_debugfs_summary_show(struct seq_file *s, void *unused)
 		   atomic64_read(&state->data_rx_bad_frame));
 	seq_printf(s, "data_rx_bad_header: %lld\n",
 		   atomic64_read(&state->data_rx_bad_header));
+	seq_printf(s, "data_rx_bad_header_parse: %lld\n",
+		   atomic64_read(&state->data_rx_bad_header_parse));
+	seq_printf(s, "data_rx_bad_header_len: %lld\n",
+		   atomic64_read(&state->data_rx_bad_header_len));
+	seq_printf(s, "data_rx_bad_header_path_credit: %lld\n",
+		   atomic64_read(&state->data_rx_bad_header_path_credit));
+	seq_printf(s, "data_rx_bad_header_opcode: %lld\n",
+		   atomic64_read(&state->data_rx_bad_header_opcode));
+	seq_printf(s, "data_rx_bad_header_recv_credit: %lld\n",
+		   atomic64_read(&state->data_rx_bad_header_recv_credit));
+	seq_printf(s, "data_rx_bad_header_ack: %lld\n",
+		   atomic64_read(&state->data_rx_bad_header_ack));
+	seq_printf(s, "data_rx_bad_header_write: %lld\n",
+		   atomic64_read(&state->data_rx_bad_header_write));
+	seq_printf(s, "data_rx_bad_header_read_req: %lld\n",
+		   atomic64_read(&state->data_rx_bad_header_read_req));
+	seq_printf(s, "data_rx_bad_header_mad: %lld\n",
+		   atomic64_read(&state->data_rx_bad_header_mad));
 	seq_printf(s, "data_rx_send: %lld\n",
 		   atomic64_read(&state->data_rx_send));
 	seq_printf(s, "data_rx_op_send: %lld\n",
@@ -345,6 +365,12 @@ static int tbv_debugfs_summary_show(struct seq_file *s, void *unused)
 		   atomic64_read(&state->apple_rx_eof_without_active));
 	seq_printf(s, "apple_rx_len_overrun: %lld\n",
 		   atomic64_read(&state->apple_rx_len_overrun));
+	seq_printf(s, "apple_rx_resync_dropped: %lld\n",
+		   atomic64_read(&state->apple_rx_resync_dropped));
+	seq_printf(s, "apple_rx_rail_mismatch: %lld\n",
+		   atomic64_read(&state->apple_rx_rail_mismatch));
+	seq_printf(s, "apple_rx_cq_overflow: %lld\n",
+		   atomic64_read(&state->apple_rx_cq_overflow));
 	seq_printf(s, "data_cq_overflow: %lld\n",
 		   atomic64_read(&state->data_cq_overflow));
 	return 0;
@@ -366,14 +392,19 @@ static int tbv_debugfs_peers_show(struct seq_file *s, void *unused)
 			   peer->nr_rails, peer->native_qp_rr_rail_id);
 
 		list_for_each_entry(rail, &peer->rails, node) {
+			bool service_ready;
 			bool data_ready;
 
-			data_ready = peer->backend == TBV_BACKEND_APPLE ?
-				tbv_rail_apple_data_ready(rail) :
-				tbv_rail_data_ready(rail);
+			if (peer->backend == TBV_BACKEND_APPLE) {
+				service_ready = tbv_rail_apple_service_ready(rail);
+				data_ready = tbv_rail_apple_data_ready(rail);
+			} else {
+				service_ready = tbv_rail_data_ready(rail);
+				data_ready = service_ready;
+			}
 
 			seq_printf(s,
-				   "  rail=0x%x route=0x%llx local=%u remote=%u path=%u link_speed=%uGb/s link_width=0x%x active=%u data_ready=%u native_qp_bind_count=%d state=%s negotiated=%u ready_sent=%u remote_ready=%u attempts=%u last_error=%d local_out=%d local_tx=%d local_rx=%d remote_rail=0x%x remote_out=%d remote_tx=%d remote_rx=%d\n",
+				   "  rail=0x%x route=0x%llx local=%u remote=%u path=%u link_speed=%uGb/s link_width=0x%x active=%u service_ready=%u data_ready=%u native_qp_bind_count=%d apple_tunnel_qps=%u state=%s negotiated=%u ready_sent=%u remote_ready=%u attempts=%u last_error=%d local_out=%d local_tx=%d local_rx=%d remote_rail=0x%x remote_out=%d remote_tx=%d remote_rx=%d\n",
 				   rail->rail_id, rail->key.route,
 				   rail->key.local_adapter,
 				   rail->key.remote_adapter,
@@ -381,8 +412,10 @@ static int tbv_debugfs_peers_show(struct seq_file *s, void *unused)
 				   rail->link_speed,
 				   rail->link_width,
 				   rail->active,
+				   service_ready,
 				   data_ready,
 				   atomic_read(&rail->native_qp_bind_count),
+				   rail->apple_tunnel_qps,
 				   tbv_path_state_name(rail->path.state),
 				   rail->native_negotiated,
 				   rail->native_ready_sent,
@@ -422,25 +455,26 @@ static int tbv_debugfs_peers_show(struct seq_file *s, void *unused)
 				   rail->path.cfg.rx_ring_size,
 				   rail->path.cfg.sof_mask,
 				   rail->path.cfg.eof_mask);
-				seq_printf(s,
-					   "    data_rx_completed=%lld data_rx_credit_sent=%lld data_rx_credit_send_error=%lld data_rx_repost_failed=%lld rx_credit_pending=%u\n",
-					   atomic64_read(&rail->path.data_rx_completed),
-					   atomic64_read(&rail->path.data_rx_credit_sent),
-					   atomic64_read(&rail->path.data_rx_credit_send_error),
-					   atomic64_read(&rail->path.data_rx_repost_failed),
-					   rail->path.rx_data_credit_pending);
-				seq_printf(s,
-					   "    tx_poll enabled=%u calls=%lld completed=%lld\n",
-					   rail->path.tx_poll_enabled,
-					   atomic64_read(&rail->path.tx_poll_calls),
-					   atomic64_read(&rail->path.tx_poll_completed));
-				seq_printf(s,
-					   "    rx_supp_poll enabled=%u calls=%lld completed=%lld\n",
-					   rail->path.rx_supp_poll_enabled,
-					   atomic64_read(&rail->path.rx_supp_poll_calls),
-					   atomic64_read(&rail->path.rx_supp_poll_completed));
-			}
+			seq_printf(s,
+				   "    data_rx_completed=%lld data_rx_canceled=%lld data_rx_credit_sent=%lld data_rx_credit_send_error=%lld data_rx_repost_failed=%lld rx_credit_pending=%u\n",
+				   atomic64_read(&rail->path.data_rx_completed),
+				   atomic64_read(&rail->path.data_rx_canceled),
+				   atomic64_read(&rail->path.data_rx_credit_sent),
+				   atomic64_read(&rail->path.data_rx_credit_send_error),
+				   atomic64_read(&rail->path.data_rx_repost_failed),
+				   rail->path.rx_data_credit_pending);
+			seq_printf(s,
+				   "    tx_poll enabled=%u calls=%lld completed=%lld\n",
+				   rail->path.tx_poll_enabled,
+				   atomic64_read(&rail->path.tx_poll_calls),
+				   atomic64_read(&rail->path.tx_poll_completed));
+			seq_printf(s,
+				   "    rx_supp_poll enabled=%u calls=%lld completed=%lld\n",
+				   rail->path.rx_supp_poll_enabled,
+				   atomic64_read(&rail->path.rx_supp_poll_calls),
+				   atomic64_read(&rail->path.rx_supp_poll_completed));
 		}
+	}
 	mutex_unlock(&state->lock);
 
 	return 0;

--- a/kernel/ibdev.c
+++ b/kernel/ibdev.c
@@ -100,10 +100,10 @@ MODULE_PARM_DESC(qp_timeout_ms,
 		 "Fallback milliseconds for pending native/Apple WRs and partial native receives "
 		 "when a QP has no verbs ACK timeout; 0 disables fallback timeout work");
 
-static uint apple_tx_max_inflight_wr = 16;
+static uint apple_tx_max_inflight_wr = 1;
 module_param(apple_tx_max_inflight_wr, uint, 0644);
 MODULE_PARM_DESC(apple_tx_max_inflight_wr,
-		 "Maximum Apple-compatible UC SEND work requests in flight per QP; 0 disables the software window");
+		 "Maximum Apple-compatible single-frame UC SEND work requests in flight per QP; multi-frame SENDs are serialized by protocol");
 
 static uint apple_tx_max_inflight_frames = 64;
 module_param(apple_tx_max_inflight_frames, uint, 0644);
@@ -148,6 +148,92 @@ static bool tbv_apple_rx_trace_take(void)
 		 remaining);
 
 	return true;
+}
+
+static void tbv_rx_bad_header_context(const struct tbv_path *rx_path,
+				      u32 *peer_id, u32 *rail_id,
+				      u32 *path_id, u64 *route)
+{
+	*peer_id = U32_MAX;
+	*rail_id = U32_MAX;
+	*path_id = 0;
+	*route = 0;
+	if (!rx_path || !rx_path->rail)
+		return;
+
+	*rail_id = rx_path->rail->rail_id;
+	*path_id = rx_path->rail->key.path_id;
+	*route = rx_path->rail->key.route;
+	if (rx_path->rail->peer)
+		*peer_id = rx_path->rail->peer->peer_id;
+}
+
+static void tbv_rx_bad_header_note(struct tbv_state *state,
+				   struct tbv_path *rx_path,
+				   atomic64_t *reason_counter,
+				   const char *reason,
+				   const struct tbv_native_data_header *hdr,
+				   u32 frame_len, int ret)
+{
+	u32 peer_id;
+	u32 rail_id;
+	u32 path_id;
+	u64 route;
+
+	atomic64_inc(&state->data_rx_bad_header);
+	if (reason_counter)
+		atomic64_inc(reason_counter);
+
+	tbv_rx_bad_header_context(rx_path, &peer_id, &rail_id, &path_id, &route);
+	if (hdr) {
+		pr_warn_ratelimited("native RX bad header reason=%s ret=%d frame_len=%u op=%u flags=0x%x len=%u imm=%u psn=%u dst=%u src=%u off=%u peer=%u rail=%u path_id=%u route=0x%llx\n",
+				    reason, ret, frame_len, hdr->opcode,
+				    hdr->flags, hdr->length, hdr->imm_data,
+				    hdr->psn, hdr->dest_qp, hdr->src_qp,
+				    hdr->frag_offset, peer_id, rail_id, path_id,
+				    (unsigned long long)route);
+	} else {
+		pr_warn_ratelimited("native RX bad header reason=%s ret=%d frame_len=%u peer=%u rail=%u path_id=%u route=0x%llx\n",
+				    reason, ret, frame_len, peer_id, rail_id,
+				    path_id, (unsigned long long)route);
+	}
+}
+
+static void tbv_rx_bad_header_parse_note(struct tbv_state *state,
+					 struct tbv_path *rx_path,
+					 const void *data, u32 len, int ret)
+{
+	const tbv_wire_u8 *p = data;
+	u32 peer_id;
+	u32 rail_id;
+	u32 path_id;
+	u64 route;
+	u32 magic = 0;
+	u16 version = 0;
+	u16 header_size = 0;
+	u8 opcode = 0;
+	u8 flags = 0;
+
+	atomic64_inc(&state->data_rx_bad_header);
+	atomic64_inc(&state->data_rx_bad_header_parse);
+
+	if (p) {
+		if (len >= 4)
+			magic = tbv_wire_get_le32(p);
+		if (len >= 6)
+			version = tbv_wire_get_le16(p + 4);
+		if (len >= 8)
+			header_size = tbv_wire_get_le16(p + 6);
+		if (len >= 9)
+			opcode = p[8];
+		if (len >= 10)
+			flags = p[9];
+	}
+
+	tbv_rx_bad_header_context(rx_path, &peer_id, &rail_id, &path_id, &route);
+	pr_warn_ratelimited("native RX bad header reason=parse ret=%d frame_len=%u magic=0x%x version=%u hdr_size=%u op=%u flags=0x%x peer=%u rail=%u path_id=%u route=0x%llx\n",
+			    ret, len, magic, version, header_size, opcode, flags,
+			    peer_id, rail_id, path_id, (unsigned long long)route);
 }
 
 struct tbv_ucontext {
@@ -321,6 +407,7 @@ struct tbv_qp {
 	struct list_head pending_read_resps;
 	struct list_head apple_sq;
 	struct work_struct apple_sq_work;
+	struct work_struct error_work;
 	struct delayed_work timeout_work;
 	struct ib_qp_init_attr init_attr;
 	struct ib_qp_attr attr;
@@ -365,6 +452,14 @@ struct tbv_qp {
 	bool rx_rnr_active;
 	bool closing;
 	bool timeout_work_armed;
+	bool apple_tunnel_active;
+	/*
+	 * Apple FA57 frames carry no message sequence. When a message-start
+	 * frame is dropped, the only safe resync point is the next EOF=3
+	 * boundary; until then incoming frames belong to the truncated
+	 * message and must not seed a new reassembly. Protected by rx_lock.
+	 */
+	bool apple_rx_discard;
 };
 
 struct tbv_mr {
@@ -538,6 +633,7 @@ static int tbv_rx_copy_to_wqe(struct tbv_state *state,
 			      const void *payload, u32 len, u32 *delivered);
 static void tbv_qp_flush_reorder(struct tbv_qp *tqp);
 static void tbv_qp_flush_active_rx(struct tbv_qp *tqp);
+static void tbv_qp_release_apple_tunnel(struct tbv_qp *tqp);
 static void tbv_rx_fail_active_send(struct tbv_state *state, struct tbv_qp *tqp,
 				    struct tbv_path *rx_path,
 				    enum ib_wc_status status);
@@ -987,6 +1083,27 @@ static bool tbv_qp_mark_error(struct tbv_qp *tqp)
 	}
 
 	return changed;
+}
+
+static void tbv_qp_error_work(struct work_struct *work)
+{
+	struct tbv_qp *tqp = container_of(work, struct tbv_qp, error_work);
+
+	tbv_qp_mark_error(tqp);
+	tbv_qp_put(tqp);
+}
+
+static void tbv_qp_queue_error(struct tbv_qp *tqp)
+{
+	struct workqueue_struct *wq;
+
+	if (!tbv_qp_get_live(tqp))
+		return;
+
+	wq = tqp->owner && tqp->owner->workqueue ? tqp->owner->workqueue :
+						   system_wq;
+	if (!queue_work(wq, &tqp->error_work))
+		tbv_qp_put(tqp);
 }
 
 static bool tbv_qp_allows_post(struct tbv_qp *tqp)
@@ -1699,6 +1816,32 @@ static u32 tbv_qp_rr_distance(u32 rail_id, u32 next_rail_id)
 	return U32_MAX - next_rail_id + 1 + rail_id;
 }
 
+static bool tbv_ibdev_rail_publish_ready_locked(struct tbv_state *state,
+						struct tbv_rail *rail)
+{
+	struct tbv_peer *peer;
+
+	if (!state || !rail || rail->removing)
+		return false;
+	peer = rail->peer;
+	if (!peer)
+		return false;
+
+	if (peer->backend == TBV_BACKEND_NATIVE)
+		return tbv_rail_data_ready(rail);
+	if (peer->backend != TBV_BACKEND_APPLE)
+		return false;
+
+	if (state->apple_rails_wait_tbnet &&
+	    !tbv_tbnet_minimal_path_ready(&state->tbnet_identity,
+					  peer->xd ? peer->xd->remote_uuid : NULL))
+		return false;
+	if (!tbv_rail_apple_data_ready(rail))
+		return false;
+
+	return true;
+}
+
 static struct tbv_rail *
 tbv_select_qp_rail_locked(struct tbv_ibdev *dev, enum tbv_backend_type backend,
 			  bool gsi, bool *counted)
@@ -1720,6 +1863,9 @@ tbv_select_qp_rail_locked(struct tbv_ibdev *dev, enum tbv_backend_type backend,
 		return NULL;
 
 	if (backend != TBV_BACKEND_NATIVE || gsi) {
+		if (backend == TBV_BACKEND_APPLE &&
+		    !tbv_ibdev_rail_publish_ready_locked(dev->state, home))
+			return NULL;
 		refcount_inc(&home->refcnt);
 		return home;
 	}
@@ -2034,10 +2180,7 @@ static bool tbv_ibdev_port_active(struct tbv_ibdev *dev)
 	 * backend is still up, which lies to userspace and to RCCL/UCX.
 	 */
 	mutex_lock(&dev->state->lock);
-	active = !rail->removing &&
-		 (rail->peer->backend == TBV_BACKEND_APPLE ?
-			tbv_rail_apple_data_ready(rail) :
-			tbv_rail_data_ready(rail));
+	active = tbv_ibdev_rail_publish_ready_locked(dev->state, rail);
 	mutex_unlock(&dev->state->lock);
 	return active;
 }
@@ -2444,6 +2587,7 @@ static int tbv_create_qp(struct ib_qp *qp, struct ib_qp_init_attr *init_attr,
 	INIT_LIST_HEAD(&tqp->apple_sq);
 	INIT_LIST_HEAD(&tqp->rx_reorder);
 	INIT_WORK(&tqp->apple_sq_work, tbv_apple_sq_work);
+	INIT_WORK(&tqp->error_work, tbv_qp_error_work);
 	INIT_DELAYED_WORK(&tqp->timeout_work, tbv_qp_timeout_work);
 	tqp->apple_pending_active = -1;
 	tqp->state = IB_QPS_RESET;
@@ -2576,7 +2720,150 @@ static int tbv_destroy_qp(struct ib_qp *qp, struct ib_udata *udata)
 	}
 	if (tqp->owner)
 		atomic_dec(&tqp->owner->verbs_qps);
+	tbv_qp_release_apple_tunnel(tqp);
 	tbv_qp_unbind_rail(tqp);
+	return 0;
+}
+
+static bool tbv_qp_state_uses_transport(enum ib_qp_state state)
+{
+	return state == IB_QPS_RTR || state == IB_QPS_RTS ||
+	       state == IB_QPS_SQD || state == IB_QPS_SQE;
+}
+
+static bool tbv_qp_get_apple_send_live(struct tbv_qp *tqp)
+{
+	unsigned long flags;
+	bool ok = false;
+
+	spin_lock_irqsave(&tqp->lock, flags);
+	if (!tqp->closing && tqp->state == IB_QPS_RTS &&
+	    refcount_inc_not_zero(&tqp->refs))
+		ok = true;
+	spin_unlock_irqrestore(&tqp->lock, flags);
+	return ok;
+}
+
+static int tbv_qp_ensure_apple_tunnel(struct tbv_qp *tqp, bool *acquired)
+{
+	struct tbv_rail *rail = tqp->rail;
+	struct tbv_peer *peer;
+	struct tbv_state *state;
+	bool counted = false;
+	u32 refs = 0;
+	int ret = 0;
+
+	if (acquired)
+		*acquired = false;
+	if (!tbv_qp_uses_apple_transport(tqp))
+		return 0;
+	if (!rail || !refcount_inc_not_zero(&rail->refcnt))
+		return -ENODEV;
+
+	peer = rail->peer;
+	state = peer ? peer->state : NULL;
+	if (!peer || !state || !peer->xd) {
+		tbv_rail_put(rail);
+		return -ENODEV;
+	}
+
+	mutex_lock(&peer->control_lock);
+	mutex_lock(&state->lock);
+	if (tqp->apple_tunnel_active) {
+		ret = 0;
+	} else if (rail->removing) {
+		ret = -ENODEV;
+	} else if (rail->path.state == TBV_PATH_TUNNEL_ENABLED) {
+		rail->apple_tunnel_qps++;
+		refs = rail->apple_tunnel_qps;
+		tqp->apple_tunnel_active = true;
+		counted = true;
+	} else {
+		ret = -ENOTCONN;
+	}
+	mutex_unlock(&state->lock);
+	mutex_unlock(&peer->control_lock);
+
+	if (counted)
+		pr_debug("Apple data tunnel ref acquired route=0x%llx qpn=%u refs=%u\n",
+			 peer->xd->route, tqp->base.qp_num, refs);
+	if (acquired)
+		*acquired = counted;
+	tbv_rail_put(rail);
+	return ret;
+}
+
+static void tbv_qp_release_apple_tunnel(struct tbv_qp *tqp)
+{
+	struct tbv_rail *rail = tqp->rail;
+	struct tbv_peer *peer;
+	struct tbv_state *state;
+	u32 refs = 0;
+	u64 route = 0;
+
+	if (!tbv_qp_uses_apple_transport(tqp))
+		return;
+	if (!rail || !refcount_inc_not_zero(&rail->refcnt))
+		return;
+
+	peer = rail->peer;
+	state = peer ? peer->state : NULL;
+	if (!peer || !state || !peer->xd) {
+		tbv_rail_put(rail);
+		return;
+	}
+
+	mutex_lock(&peer->control_lock);
+	mutex_lock(&state->lock);
+	if (tqp->apple_tunnel_active) {
+		tqp->apple_tunnel_active = false;
+		if (WARN_ON_ONCE(!rail->apple_tunnel_qps)) {
+			rail->apple_tunnel_qps = 0;
+		} else {
+			rail->apple_tunnel_qps--;
+		}
+		refs = rail->apple_tunnel_qps;
+		route = peer->xd->route;
+	}
+	mutex_unlock(&state->lock);
+	/*
+	 * Apple FA57 frames carry no connection incarnation, and local TX
+	 * completion does not prove the peer has consumed every frame. Treat the
+	 * enabled tunnel as a published rail resource; disabling it at last-QP
+	 * close can cut the peer's receive in the middle of a WQE. Rail teardown
+	 * still disables the tunnel through tbv_path_destroy().
+	 */
+	if (!refs)
+		pr_debug("Apple data tunnel left enabled after last QP route=0x%llx qpn=%u\n",
+			 route, tqp->base.qp_num);
+	mutex_unlock(&peer->control_lock);
+
+	tbv_rail_put(rail);
+}
+
+static int tbv_validate_modify_qp_locked(struct tbv_qp *tqp,
+					 struct ib_qp_attr *attr, int attr_mask,
+					 enum ib_qp_state *cur_state,
+					 enum ib_qp_state *next_state)
+{
+	*cur_state = tqp->state;
+	*next_state = (attr_mask & IB_QP_STATE) ? attr->qp_state : *cur_state;
+
+	if ((attr_mask & IB_QP_CUR_STATE) &&
+	    attr->cur_qp_state != *cur_state)
+		return -EINVAL;
+	if (!ib_modify_qp_is_ok(*cur_state, *next_state, tqp->type, attr_mask)) {
+		pr_warn_ratelimited("modify_qp invalid transition qpn=%u backend=%u type=%u cur=%u next=%u mask=0x%x\n",
+				    tqp->base.qp_num, tqp->backend, tqp->type,
+				    *cur_state, *next_state, attr_mask);
+		return -EINVAL;
+	}
+
+	if ((attr_mask & IB_QP_DEST_QPN) &&
+	    tqp->early_remote_recv_credit_src_known &&
+	    tqp->early_remote_recv_credit_src_qp != attr->dest_qp_num)
+		return -EINVAL;
+
 	return 0;
 }
 
@@ -2587,6 +2874,9 @@ static int tbv_modify_qp(struct ib_qp *qp, struct ib_qp_attr *attr,
 	enum ib_qp_state cur_state;
 	enum ib_qp_state next_state;
 	unsigned long flags;
+	bool activate_apple_tunnel = false;
+	bool deactivate_apple_tunnel = false;
+	bool apple_tunnel_acquired = false;
 	bool flush_error = false;
 	int ret = 0;
 
@@ -2601,22 +2891,34 @@ static int tbv_modify_qp(struct ib_qp *qp, struct ib_qp_attr *attr,
 		return -EINVAL;
 
 	spin_lock_irqsave(&tqp->lock, flags);
-	cur_state = tqp->state;
-	next_state = (attr_mask & IB_QP_STATE) ? attr->qp_state : cur_state;
-	if ((attr_mask & IB_QP_CUR_STATE) && attr->cur_qp_state != cur_state) {
-		ret = -EINVAL;
-		goto out_unlock;
+	ret = tbv_validate_modify_qp_locked(tqp, attr, attr_mask, &cur_state,
+					    &next_state);
+	if (!ret && tbv_qp_uses_apple_transport(tqp)) {
+		activate_apple_tunnel =
+			tbv_qp_state_uses_transport(next_state);
+		deactivate_apple_tunnel =
+			tbv_qp_state_uses_transport(cur_state) &&
+			!tbv_qp_state_uses_transport(next_state);
 	}
-	if (!ib_modify_qp_is_ok(cur_state, next_state, tqp->type, attr_mask)) {
-		pr_warn_ratelimited("modify_qp invalid transition qpn=%u backend=%u type=%u cur=%u next=%u mask=0x%x\n",
-				    qp->qp_num, tqp->backend, tqp->type,
-				    cur_state, next_state, attr_mask);
-		ret = -EINVAL;
-		goto out_unlock;
+	spin_unlock_irqrestore(&tqp->lock, flags);
+	if (ret)
+		return ret;
+
+	if (activate_apple_tunnel) {
+		ret = tbv_qp_ensure_apple_tunnel(tqp,
+						 &apple_tunnel_acquired);
+		if (ret)
+			return ret;
 	}
 
+	spin_lock_irqsave(&tqp->lock, flags);
+	ret = tbv_validate_modify_qp_locked(tqp, attr, attr_mask, &cur_state,
+					    &next_state);
+	if (ret)
+		goto out_unlock;
+
 	if (attr_mask & IB_QP_STATE) {
-		flush_error = tqp->state != IB_QPS_ERR &&
+		flush_error = cur_state != IB_QPS_ERR &&
 			      attr->qp_state == IB_QPS_ERR;
 		tqp->state = attr->qp_state;
 		tqp->attr.qp_state = attr->qp_state;
@@ -2634,11 +2936,6 @@ static int tbv_modify_qp(struct ib_qp *qp, struct ib_qp_attr *attr,
 	if (attr_mask & IB_QP_PATH_MTU)
 		tqp->attr.path_mtu = attr->path_mtu;
 	if (attr_mask & IB_QP_DEST_QPN) {
-		if (tqp->early_remote_recv_credit_src_known &&
-		    tqp->early_remote_recv_credit_src_qp != attr->dest_qp_num) {
-			ret = -EINVAL;
-			goto out_unlock;
-		}
 		tqp->attr.dest_qp_num = attr->dest_qp_num;
 		tqp->dest_qp_known = true;
 	}
@@ -2666,10 +2963,18 @@ static int tbv_modify_qp(struct ib_qp *qp, struct ib_qp_attr *attr,
 		tqp->attr.max_rd_atomic = attr->max_rd_atomic;
 out_unlock:
 	spin_unlock_irqrestore(&tqp->lock, flags);
-	if (ret)
+	if (ret) {
+		if (apple_tunnel_acquired)
+			tbv_qp_release_apple_tunnel(tqp);
 		return ret;
-	if (flush_error)
+	}
+	if (flush_error || deactivate_apple_tunnel) {
 		tbv_qp_flush_error(tqp);
+		if (deactivate_apple_tunnel)
+			flush_work(&tqp->apple_sq_work);
+	}
+	if (deactivate_apple_tunnel)
+		tbv_qp_release_apple_tunnel(tqp);
 	if (attr_mask & (IB_QP_STATE | IB_QP_DEST_QPN))
 		tbv_qp_advertise_recv_credits(tqp);
 	return 0;
@@ -3084,6 +3389,39 @@ static void tbv_apple_send_complete_work(struct work_struct *work)
 
 	tbv_send_complete(send, send->apple_complete_status);
 	tbv_send_ctx_put(send);
+}
+
+static void tbv_apple_complete_ordered_sends(struct tbv_qp *tqp,
+					     struct list_head *complete)
+{
+	while (!list_empty(complete)) {
+		struct tbv_send_ctx *send =
+			list_first_entry(complete, struct tbv_send_ctx, node);
+		int status = send->completion_status;
+
+		list_del_init(&send->node);
+		if (!status) {
+			u32 delay_us = READ_ONCE(apple_tx_completion_delay_us);
+
+			if (delay_us) {
+				struct workqueue_struct *wq =
+					tqp->owner && tqp->owner->workqueue ?
+						tqp->owner->workqueue :
+						system_unbound_wq;
+				unsigned long delay =
+					max_t(unsigned long, 1,
+					      usecs_to_jiffies(delay_us));
+
+				send->apple_complete_status = 0;
+				queue_delayed_work(wq, &send->apple_complete_work,
+						   delay);
+				continue;
+			}
+		}
+
+		tbv_send_complete(send, status);
+		tbv_send_ctx_put(send);
+	}
 }
 
 static bool tbv_qp_timeout_reap_tx(struct tbv_qp *tqp,
@@ -3724,33 +4062,12 @@ static void tbv_apple_send_tx_done(void *ctx, int status)
 
 	last = atomic_dec_and_test(&send->apple_pending);
 	wake_up_all(&tqp->apple_tx_wait);
-	if (status) {
-		if (tbv_qp_unqueue_send(tqp, send)) {
-			tbv_send_complete(send, status);
-			tbv_send_ctx_put(send);
-		}
-	} else if (last) {
-		if (tbv_qp_unqueue_send(tqp, send)) {
-			u32 delay_us = READ_ONCE(apple_tx_completion_delay_us);
+	if (status || last) {
+		LIST_HEAD(complete);
 
-			if (delay_us) {
-				struct workqueue_struct *wq =
-					tqp->owner && tqp->owner->workqueue ?
-						tqp->owner->workqueue :
-						system_unbound_wq;
-				unsigned long delay =
-					max_t(unsigned long, 1,
-					      usecs_to_jiffies(delay_us));
-
-				send->apple_complete_status = 0;
-				queue_delayed_work(wq,
-						   &send->apple_complete_work,
-						   delay);
-			} else {
-				tbv_send_complete(send, 0);
-				tbv_send_ctx_put(send);
-			}
-		}
+		if (tbv_qp_complete_send_ordered(tqp, send->psn, status,
+						 &complete, NULL))
+			tbv_apple_complete_ordered_sends(tqp, &complete);
 	}
 
 	tbv_send_ctx_put(send);
@@ -3840,11 +4157,11 @@ static int tbv_post_apple_send(struct tbv_qp *tqp, const struct ib_send_wr *wr)
 		return -EOPNOTSUPP;
 	if (!tbv_qp_has_dest_qp(tqp))
 		return -EINVAL;
+	if (!tbv_qp_get_apple_send_live(tqp))
+		return -EINVAL;
 
 	atomic64_inc(&tqp->owner->data_wr_send);
 	atomic64_inc(&tqp->owner->data_wr_op_send);
-	if (!tbv_qp_get_live(tqp))
-		return -EINVAL;
 	atomic64_inc(&tqp->owner->data_wr_live);
 
 	ret = tbv_prepare_send_segments(tqp, wr, segs, &nsegs, &total_len);
@@ -5097,7 +5414,7 @@ static int tbv_cq_push(struct tbv_cq *tcq, const struct ib_wc *wc)
 out:
 	spin_unlock_irqrestore(&tcq->lock, flags);
 	if (overflow_qp)
-		tbv_qp_mark_error(overflow_qp);
+		tbv_qp_queue_error(overflow_qp);
 	if (notify && tcq->base.comp_handler)
 		tcq->base.comp_handler(&tcq->base, tcq->base.cq_context);
 	return ret;
@@ -5127,6 +5444,7 @@ static void tbv_qp_flush_apple_pending(struct tbv_qp *tqp)
 {
 	u32 i;
 
+	tqp->apple_rx_discard = false;
 	if (!tqp->apple_pending) {
 		tqp->apple_pending_head = 0;
 		tqp->apple_pending_tail = 0;
@@ -5206,7 +5524,12 @@ static void tbv_apple_rx_push_wc(struct tbv_qp *tqp,
 	wc.src_qp = tqp->attr.dest_qp_num;
 	wc.pkey_index = 0;
 	wc.port_num = 1;
-	tbv_cq_push(recv_cq, &wc);
+	if (tbv_cq_push(recv_cq, &wc)) {
+		/* tbv_cq_push already queued QP error handling. */
+		atomic64_inc(&tqp->owner->apple_rx_cq_overflow);
+		pr_warn_ratelimited("apple rx CQ overflow qpn=%u byte_len=%u\n",
+				    tqp->base.qp_num, byte_len);
+	}
 }
 
 static void tbv_apple_rx_drain_pending_locked(struct tbv_state *state,
@@ -5353,6 +5676,7 @@ void tbv_ibdev_rx_apple_frame(struct tbv_state *state,
 {
 	struct tbv_apple_pending_rx *pending;
 	struct tbv_qp *tqp;
+	bool starts_message;
 	bool raw_rx;
 	u32 qpn;
 	u32 user_len = 0;
@@ -5380,12 +5704,48 @@ void tbv_ibdev_rx_apple_frame(struct tbv_state *state,
 		return;
 	}
 
+	/*
+	 * macOS emits short single-frame SENDs as EOF=3 without SOF. Treat
+	 * those as a complete message start, but keep rejecting idle non-final
+	 * fragments because there is no Apple-side sequence number to recover
+	 * the missing prefix.
+	 */
+	starts_message = sof || raw_rx || eof == TBV_DATA_PDF_FRAME_END;
+
+	/*
+	 * Apple frames carry no QPN; demux is by inbound hop ID only, and
+	 * every Apple path uses the same hop. Make sure this QP is bound to
+	 * the rail the frame actually arrived on so a second Apple peer can
+	 * never feed another peer's QP.
+	 */
+	if (!tqp->rail || tqp->rail != path->rail) {
+		atomic64_inc(&state->apple_rx_rail_mismatch);
+		atomic64_inc(&state->data_rx_no_qp);
+		pr_warn_ratelimited("apple rx frame from unbound rail qpn=%u\n",
+				    qpn);
+		tbv_qp_put(tqp);
+		return;
+	}
+
 	mutex_lock(&tqp->rx_lock);
 	if (tqp->apple_pending_ready_count)
 		tbv_apple_rx_drain_pending_locked(state, tqp);
+	if (tqp->apple_rx_discard) {
+		/*
+		 * Resynchronizing after a dropped message start: swallow
+		 * frames up to the EOF=3 boundary so the tail of a truncated
+		 * message is never delivered as a complete message.
+		 */
+		atomic64_inc(&state->apple_rx_resync_dropped);
+		if (eof == 3)
+			tqp->apple_rx_discard = false;
+		mutex_unlock(&tqp->rx_lock);
+		tbv_qp_put(tqp);
+		return;
+	}
 	if (sof && tqp->apple_pending_active >= 0)
 		atomic64_inc(&state->apple_rx_sof_while_active);
-	if (tqp->apple_pending_active < 0 && !sof && !raw_rx) {
+	if (tqp->apple_pending_active < 0 && !starts_message) {
 		atomic64_inc(&state->apple_rx_no_sof_when_idle);
 		atomic64_inc(&state->data_rx_bad_frame);
 		mutex_unlock(&tqp->rx_lock);
@@ -5397,6 +5757,14 @@ void tbv_ibdev_rx_apple_frame(struct tbv_state *state,
 	if (!pending) {
 		atomic64_inc(&state->data_rx_no_recv);
 		atomic64_inc(&state->data_rx_reorder_dropped);
+		/*
+		 * A message-start frame was dropped. Unless this frame also
+		 * carried the message's EOF=3, the rest of the message is
+		 * still inbound and must be discarded at the boundary, not
+		 * delivered as a fresh (truncated) message.
+		 */
+		if (eof != 3)
+			tqp->apple_rx_discard = true;
 		mutex_unlock(&tqp->rx_lock);
 		tbv_qp_put(tqp);
 		return;
@@ -5755,6 +6123,17 @@ static u32 tbv_apple_tx_frame_charge(u32 frames, unsigned int max_frames)
 	return min_t(u32, frames, max_frames);
 }
 
+static bool tbv_apple_tx_requires_exclusive_window(u32 frames)
+{
+	/*
+	 * Apple FA57 RX frames carry SOF/EOF but no message sequence. Multiple
+	 * multi-frame SENDs in flight can therefore interleave at the peer and
+	 * produce partial or misassembled WQEs. Single-frame SENDs are self
+	 * delimiting and may still use the normal software window.
+	 */
+	return frames > 1;
+}
+
 static bool tbv_qp_try_acquire_apple_tx_window(struct tbv_qp *tqp, u32 frames,
 					       bool *wr_acquired,
 					       u32 *frames_acquired,
@@ -5763,10 +6142,11 @@ static bool tbv_qp_try_acquire_apple_tx_window(struct tbv_qp *tqp, u32 frames,
 	unsigned int max_wr = READ_ONCE(apple_tx_max_inflight_wr);
 	unsigned int max_frames = READ_ONCE(apple_tx_max_inflight_frames);
 	u32 frame_charge = tbv_apple_tx_frame_charge(frames, max_frames);
+	bool exclusive = tbv_apple_tx_requires_exclusive_window(frames);
 	unsigned long flags;
 	bool acquired = false;
 
-	if (!max_wr && !max_frames) {
+	if (!exclusive && !max_wr && !max_frames) {
 		*wr_acquired = false;
 		*frames_acquired = 0;
 		*ret = 0;
@@ -5774,23 +6154,23 @@ static bool tbv_qp_try_acquire_apple_tx_window(struct tbv_qp *tqp, u32 frames,
 	}
 
 	spin_lock_irqsave(&tqp->lock, flags);
-	if (tqp->closing || tqp->state == IB_QPS_ERR) {
+	if (tqp->closing || !tbv_qp_state_uses_transport(tqp->state)) {
 		*ret = -ECANCELED;
 		acquired = true;
 	} else {
 		int cur_wr = atomic_read(&tqp->apple_tx_inflight);
 		int cur_frames = atomic_read(&tqp->apple_tx_inflight_frames);
-		bool wr_ok = !max_wr || cur_wr < max_wr;
+		bool wr_ok = exclusive ? !cur_wr : (!max_wr || cur_wr < max_wr);
 		bool frames_ok = !max_frames ||
 			cur_frames + frame_charge <= max_frames;
 
-		if (wr_ok && frames_ok) {
-			if (max_wr)
+		if (wr_ok && frames_ok && (!exclusive || !cur_frames)) {
+			if (max_wr || exclusive)
 				atomic_inc(&tqp->apple_tx_inflight);
 			if (frame_charge)
 				atomic_add(frame_charge,
 					   &tqp->apple_tx_inflight_frames);
-			*wr_acquired = !!max_wr;
+			*wr_acquired = !!max_wr || exclusive;
 			*frames_acquired = frame_charge;
 			*ret = 0;
 			acquired = true;
@@ -5805,20 +6185,22 @@ static bool tbv_qp_apple_tx_window_available(struct tbv_qp *tqp, u32 frames)
 	unsigned int max_wr = READ_ONCE(apple_tx_max_inflight_wr);
 	unsigned int max_frames = READ_ONCE(apple_tx_max_inflight_frames);
 	u32 frame_charge = tbv_apple_tx_frame_charge(frames, max_frames);
+	bool exclusive = tbv_apple_tx_requires_exclusive_window(frames);
 	unsigned long flags;
 	bool available;
 
-	if (!max_wr && !max_frames)
+	if (!exclusive && !max_wr && !max_frames)
 		return true;
 
 	spin_lock_irqsave(&tqp->lock, flags);
-	if (tqp->closing || tqp->state == IB_QPS_ERR) {
+	if (tqp->closing || !tbv_qp_state_uses_transport(tqp->state)) {
 		available = true;
 	} else {
 		int cur_wr = atomic_read(&tqp->apple_tx_inflight);
 		int cur_frames = atomic_read(&tqp->apple_tx_inflight_frames);
 
-		available = (!max_wr || cur_wr < max_wr) &&
+		available = (exclusive ? !cur_wr : (!max_wr || cur_wr < max_wr)) &&
+			    (!exclusive || !cur_frames) &&
 			    (!max_frames ||
 			     cur_frames + frame_charge <= max_frames);
 	}
@@ -5853,7 +6235,7 @@ static bool tbv_qp_apple_sq_stopping(struct tbv_qp *tqp)
 	bool stopping;
 
 	spin_lock_irqsave(&tqp->lock, flags);
-	stopping = tqp->closing || tqp->state == IB_QPS_ERR;
+	stopping = tqp->closing || !tbv_qp_state_uses_transport(tqp->state);
 	spin_unlock_irqrestore(&tqp->lock, flags);
 	return stopping;
 }
@@ -6026,7 +6408,8 @@ static int tbv_apple_sq_transmit(struct tbv_qp *tqp,
 		remaining = pending_descs;
 	}
 
-	ret = tbv_apple_sq_get_tx_resources(tqp, nfrags, pending_descs, &path,
+	ret = tbv_apple_sq_get_tx_resources(tqp, pending_descs, pending_descs,
+					    &path,
 					    &apple_wr_acquired,
 					    &apple_frames_acquired);
 	if (ret)
@@ -6043,6 +6426,11 @@ static int tbv_apple_sq_transmit(struct tbv_qp *tqp,
 		u32 payload_len = min_t(u32, entry->length - offset,
 					TBV_APPLE_FRAME_SIZE);
 		bool last = offset + payload_len == entry->length;
+
+		if (tbv_qp_apple_sq_stopping(tqp)) {
+			ret = -ECANCELED;
+			goto err_release_reservation;
+		}
 
 		if (raw_mode) {
 			ret = tbv_apple_sq_transmit_raw_chunk(
@@ -6803,6 +7191,7 @@ static void tbv_qp_flush_error(struct tbv_qp *tqp)
 	tbv_rx_fail_active_write_locked(tqp->owner, tqp, NULL,
 					    IB_WC_WR_FLUSH_ERR);
 	tbv_qp_flush_reorder(tqp);
+	tbv_qp_flush_apple_pending(tqp);
 	mutex_unlock(&tqp->rx_lock);
 
 	tbv_qp_flush_recv_wqes(tqp);
@@ -7735,7 +8124,10 @@ static void tbv_rx_handle_rdma_write_fragment(struct tbv_state *state,
 			   last != (frag_end == total_len))) ||
 	    (!last && !hdr->length) ||
 	    !(tqp->attr.qp_access_flags & IB_ACCESS_REMOTE_WRITE)) {
-		atomic64_inc(&state->data_rx_bad_header);
+		tbv_rx_bad_header_note(state, rx_path,
+				       &state->data_rx_bad_header_write,
+				       "write", hdr,
+				       TBV_NATIVE_DATA_HDR_SIZE + hdr->length, 0);
 		tbv_send_ack_on_path(tqp, rx_path, hdr->src_qp,
 				     hdr->dest_qp, hdr->psn,
 				     TBV_NATIVE_SEND_ACK_ERROR);
@@ -8210,7 +8602,10 @@ static void tbv_rx_handle_rdma_read_req(struct tbv_state *state,
 
 	if (hdr->length || !(hdr->flags & TBV_NATIVE_DATA_F_LAST) ||
 	    (hdr->flags & ~TBV_NATIVE_DATA_F_LAST)) {
-		atomic64_inc(&state->data_rx_bad_header);
+		tbv_rx_bad_header_note(state, rx_path,
+				       &state->data_rx_bad_header_read_req,
+				       "read_req", hdr,
+				       TBV_NATIVE_DATA_HDR_SIZE + hdr->length, 0);
 		tbv_send_read_status_on_path(tqp, rx_path, hdr->src_qp,
 					     hdr->dest_qp, hdr->psn,
 					     hdr->imm_data, -EINVAL);
@@ -8387,14 +8782,20 @@ static void tbv_rx_handle_mad(struct tbv_state *state, struct tbv_path *rx_path,
 	if (!rx_path || hdr->flags != TBV_NATIVE_DATA_F_LAST ||
 	    hdr->dest_qp != TBV_GSI_QPN || hdr->src_qp != TBV_GSI_QPN ||
 	    hdr->imm_data != sizeof(struct ib_mad)) {
-		atomic64_inc(&state->data_rx_bad_header);
+		tbv_rx_bad_header_note(state, rx_path,
+				       &state->data_rx_bad_header_mad,
+				       "mad_header", hdr,
+				       TBV_NATIVE_DATA_HDR_SIZE + hdr->length, 0);
 		return;
 	}
 
 	ret = tbv_gsi_meta_parse(payload, hdr->length, &sgid, &dgid,
 				 &pkey_index, &mad, &mad_len);
 	if (ret || mad_len != sizeof(struct ib_mad)) {
-		atomic64_inc(&state->data_rx_bad_header);
+		tbv_rx_bad_header_note(state, rx_path,
+				       &state->data_rx_bad_header_mad,
+				       "mad_meta", hdr,
+				       TBV_NATIVE_DATA_HDR_SIZE + hdr->length, ret);
 		return;
 	}
 
@@ -8469,7 +8870,10 @@ void tbv_ibdev_rx_native_frame(struct tbv_state *state,
 	case TBV_NATIVE_DATA_OP_MAD:
 		break;
 	default:
-		atomic64_inc(&state->data_rx_bad_header);
+		tbv_rx_bad_header_note(state, rx_path,
+				       &state->data_rx_bad_header_opcode,
+				       "opcode", hdr,
+				       TBV_NATIVE_DATA_HDR_SIZE + hdr->length, 0);
 		return;
 	}
 
@@ -8487,7 +8891,11 @@ void tbv_ibdev_rx_native_frame(struct tbv_state *state,
 	if (hdr->opcode == TBV_NATIVE_DATA_OP_RECV_CREDIT) {
 		atomic64_inc(&state->data_rx_ack);
 		if (!hdr->imm_data) {
-			atomic64_inc(&state->data_rx_bad_header);
+			tbv_rx_bad_header_note(state, rx_path,
+					       &state->data_rx_bad_header_recv_credit,
+					       "recv_credit", hdr,
+					       TBV_NATIVE_DATA_HDR_SIZE +
+					       hdr->length, 0);
 			tbv_qp_put(tqp);
 			return;
 		}
@@ -8547,7 +8955,11 @@ void tbv_ibdev_rx_native_frame(struct tbv_state *state,
 				tqp, hdr->psn, status, &acked, &matched_send);
 			break;
 		default:
-			atomic64_inc(&state->data_rx_bad_header);
+			tbv_rx_bad_header_note(state, rx_path,
+					       &state->data_rx_bad_header_ack,
+					       "send_ack", hdr,
+					       TBV_NATIVE_DATA_HDR_SIZE +
+					       hdr->length, 0);
 			tbv_qp_put(tqp);
 			return;
 		}
@@ -8641,11 +9053,13 @@ void tbv_ibdev_rx_frame(struct tbv_state *state, struct tbv_path *rx_path,
 
 	ret = tbv_native_data_parse_header(data, len, &hdr);
 	if (ret) {
-		atomic64_inc(&state->data_rx_bad_header);
+		tbv_rx_bad_header_parse_note(state, rx_path, data, len, ret);
 		return;
 	}
 	if (hdr.length > len - TBV_NATIVE_DATA_HDR_SIZE) {
-		atomic64_inc(&state->data_rx_bad_header);
+		tbv_rx_bad_header_note(state, rx_path,
+				       &state->data_rx_bad_header_len,
+				       "frame_len", &hdr, len, 0);
 		return;
 	}
 
@@ -8993,11 +9407,7 @@ int tbv_ibdev_rail_event(struct tbv_state *state, struct tbv_rail *rail,
 	 * "is this rail going away" is rail->removing, which is monotonic.
 	 */
 	mutex_lock(&state->lock);
-	if (rail->peer->backend == TBV_BACKEND_NATIVE)
-		ready = tbv_rail_data_ready(rail);
-	else
-		ready = tbv_rail_apple_data_ready(rail);
-	ready = ready && !rail->removing;
+	ready = tbv_ibdev_rail_publish_ready_locked(state, rail);
 	mutex_unlock(&state->lock);
 	if (!ready) {
 		mutex_unlock(&state->rail_register_lock);
@@ -9083,14 +9493,10 @@ static void tbv_ibdev_netdev_retry_work(struct work_struct *work)
 				    READ_ONCE(rail->ibdev) ||
 				    READ_ONCE(rail->ibdev_register_failed))
 					continue;
-				if (!tbv_ibdev_required_netdev_registered(state,
-									 rail))
+				if (!tbv_ibdev_required_netdev_registered(state, rail))
 					continue;
-				if (peer->backend == TBV_BACKEND_NATIVE)
-					ready = tbv_rail_data_ready(rail);
-				else
-					ready = tbv_rail_apple_data_ready(rail);
-				if (!ready || rail->removing)
+				ready = tbv_ibdev_rail_publish_ready_locked(state, rail);
+				if (!ready)
 					continue;
 				refcount_inc(&rail->refcnt);
 				target = rail;
@@ -9271,11 +9677,8 @@ int tbv_ibdev_start(struct tbv_state *state, bool register_verbs)
 				    READ_ONCE(rail->ibdev_register_failed) ||
 				    READ_ONCE(rail->ibdev_register_deferred))
 					continue;
-				if (peer->backend == TBV_BACKEND_NATIVE)
-					ready = tbv_rail_data_ready(rail);
-				else
-					ready = tbv_rail_apple_data_ready(rail);
-				if (!ready || rail->removing)
+				ready = tbv_ibdev_rail_publish_ready_locked(state, rail);
+				if (!ready)
 					continue;
 				refcount_inc(&rail->refcnt);
 				catchup = rail;

--- a/kernel/path.c
+++ b/kernel/path.c
@@ -16,7 +16,7 @@
  * recycle. 1024 entries passed checked Mac-to-Linux UC bursts beyond one full
  * ring while keeping per-direction buffer cost modest.
  */
-#define TBV_APPLE_RING_SIZE 16384
+#define TBV_APPLE_RING_SIZE 1024
 #define TBV_DATA_FRAME_SIZE SZ_4K
 #define TBV_CONTROL_FRAME_SIZE 256
 #define TBV_CONTROL_QUEUE_MULTIPLIER 4
@@ -80,6 +80,11 @@ module_param(apple_rx_raw_mode, bool, 0644);
 MODULE_PARM_DESC(apple_rx_raw_mode,
 		 "Use RAW descriptors for Apple-compatible RX rings; default keeps FRAME reassembly");
 
+static uint native_tx_max_inflight = TBV_DATA_TX_MAX_INFLIGHT;
+module_param(native_tx_max_inflight, uint, 0644);
+MODULE_PARM_DESC(native_tx_max_inflight,
+		 "Maximum native data TX descriptors posted per path before waiting for completions; 0 disables native throttling");
+
 struct tbv_data_frame {
 	struct ring_frame frame;
 	struct tbv_path *path;
@@ -133,6 +138,19 @@ static u32 tbv_path_control_packet_count(const struct tbv_path *path)
 	u32 count = path->cfg.tx_ring_size * TBV_CONTROL_QUEUE_MULTIPLIER;
 
 	return clamp_t(u32, count, 64, 4096);
+}
+
+static u32 tbv_path_tx_inflight_limit(const struct tbv_path *path)
+{
+	u32 limit = TBV_DATA_TX_MAX_INFLIGHT;
+
+	if (path->rail && path->rail->peer &&
+	    path->rail->peer->backend == TBV_BACKEND_NATIVE)
+		limit = READ_ONCE(native_tx_max_inflight);
+	if (!limit)
+		return 0;
+
+	return clamp_t(u32, limit, 1, path->cfg.tx_ring_size);
 }
 
 static u32 tbv_path_data_packet_count(const struct tbv_path *path)
@@ -246,8 +264,12 @@ static bool tbv_path_progress_poll_enabled(const struct tbv_path *path)
 	if (!path->rail || !path->rail->peer)
 		return false;
 
-	return path->rail->peer->backend == TBV_BACKEND_NATIVE ||
-	       path->rail->peer->backend == TBV_BACKEND_APPLE;
+	/*
+	 * Apple FA57 has no transport-level ACK. Early local TX polling can open
+	 * the verbs SQ window before macOS has consumed the previous SEND group.
+	 * Use normal NHI TX callbacks for Apple and reserve polling for native.
+	 */
+	return path->rail->peer->backend == TBV_BACKEND_NATIVE;
 }
 
 static void tbv_path_queue_delayed_work(struct tbv_path *path,
@@ -834,8 +856,12 @@ static void tbv_path_rx_complete(struct tb_ring *ring, struct ring_frame *frame,
 	u32 add_remote_credits = 0;
 	bool was_raw_payload;
 
-	if (canceled)
+	if (canceled) {
+		if (state)
+			atomic64_inc(&state->data_rx_canceled);
+		atomic64_inc(&path->data_rx_canceled);
 		return;
+	}
 	if (state)
 		atomic64_inc(&state->data_rx_completed);
 	atomic64_inc(&path->data_rx_completed);
@@ -855,14 +881,32 @@ static void tbv_path_rx_complete(struct tb_ring *ring, struct ring_frame *frame,
 			return_rx_credits = 1;
 			tbv_path_rx_raw_payload(path, state, f->buf, len);
 		} else {
-			ret = tbv_native_data_parse_header(f->buf, len, &hdr);
-			if (!ret && hdr.opcode == TBV_NATIVE_DATA_OP_PATH_CREDIT) {
-				if (tbv_native_data_valid_path_credit(&hdr))
-					add_remote_credits = hdr.imm_data;
-				else
-					atomic64_inc(&state->data_rx_bad_header);
-			} else if (!ret &&
-				   (hdr.flags & TBV_NATIVE_DATA_F_RAW_STREAM)) {
+				ret = tbv_native_data_parse_header(f->buf, len, &hdr);
+				if (!ret && hdr.opcode == TBV_NATIVE_DATA_OP_PATH_CREDIT) {
+					if (tbv_native_data_valid_path_credit(&hdr)) {
+						add_remote_credits = hdr.imm_data;
+					} else {
+						atomic64_inc(&state->data_rx_bad_header);
+						atomic64_inc(&state->data_rx_bad_header_path_credit);
+						pr_warn_ratelimited("native RX bad header reason=path_credit frame_len=%u flags=0x%x len=%u imm=%u psn=%u peer=%u rail=%u path_id=%u route=0x%llx\n",
+								    len, hdr.flags,
+								    hdr.length, hdr.imm_data,
+								    hdr.psn,
+								    path->rail && path->rail->peer ?
+								    path->rail->peer->peer_id :
+								    U32_MAX,
+								    path->rail ?
+								    path->rail->rail_id :
+								    U32_MAX,
+								    path->rail ?
+								    path->rail->key.path_id :
+								    0,
+								    path->rail ?
+								    (unsigned long long)path->rail->key.route :
+								    0);
+					}
+				} else if (!ret &&
+					   (hdr.flags & TBV_NATIVE_DATA_F_RAW_STREAM)) {
 				if (len != TBV_NATIVE_DATA_HDR_SIZE ||
 				    !hdr.length ||
 				    (hdr.flags & ~(TBV_NATIVE_DATA_F_LAST |
@@ -1304,6 +1348,26 @@ int tbv_path_enable_tunnel(struct tbv_path *path, struct tb_xdomain *xd,
 	return 0;
 }
 
+int tbv_path_disable_tunnel(struct tbv_path *path, struct tb_xdomain *xd)
+{
+	int ret;
+
+	if (path->state != TBV_PATH_TUNNEL_ENABLED)
+		return 0;
+
+	ret = tb_xdomain_disable_paths(xd, path->local_transmit_path,
+				       path->local_tx_hop,
+				       path->remote_transmit_path,
+				       path->local_rx_hop);
+	if (ret)
+		return ret;
+
+	tb_xdomain_release_in_hopid(xd, path->remote_transmit_path);
+	path->remote_transmit_path = -1;
+	path->state = TBV_PATH_RING_STARTED;
+	return 0;
+}
+
 static struct tbv_tx_packet *
 tbv_path_alloc_data_packet_owned(struct tbv_path *path, u8 *buf, u32 len,
 				 tbv_path_tx_done_fn done, void *done_ctx)
@@ -1678,12 +1742,17 @@ static void tbv_path_schedule_tx(struct tbv_path *path)
 			needs_staging = !packet->zcopy;
 		}
 
-		if (!from_control_queue &&
-		    atomic_read(&path->tx_inflight) >=
-			    TBV_DATA_TX_MAX_INFLIGHT) {
-			path->tx_scheduling = false;
-			spin_unlock_irqrestore(&path->tx_lock, flags);
-			return;
+		if (!from_control_queue) {
+			u32 tx_inflight_limit =
+				tbv_path_tx_inflight_limit(path);
+
+			if (tx_inflight_limit &&
+			    atomic_read(&path->tx_inflight) >=
+				    tx_inflight_limit) {
+				path->tx_scheduling = false;
+				spin_unlock_irqrestore(&path->tx_lock, flags);
+				return;
+			}
 		}
 
 		if (needs_staging && list_empty(&path->tx_free)) {
@@ -2482,23 +2551,26 @@ void tbv_path_destroy(struct tbv_path *path, struct tb_xdomain *xd)
 	bool rings_started = tunnel_enabled ||
 			     path->state == TBV_PATH_RING_STARTED;
 
+	cancel_delayed_work_sync(&path->tx_poll_work);
+	cancel_delayed_work_sync(&path->rx_supp_poll_work);
+
+	if (tunnel_enabled) {
+		int ret = tbv_path_disable_tunnel(path, xd);
+
+		if (ret)
+			pr_warn("disable tunnel route path tx=%d rx=%d failed: %d\n",
+				path->local_transmit_path,
+				path->remote_transmit_path, ret);
+		if (ret && path->remote_transmit_path >= 0) {
+			tb_xdomain_release_in_hopid(xd, path->remote_transmit_path);
+			path->remote_transmit_path = -1;
+		}
+	}
 	if (rings_started) {
 		if (path->rx_ring)
 			tb_ring_stop(path->rx_ring);
 		if (path->tx_ring)
 			tb_ring_stop(path->tx_ring);
-		path->state = TBV_PATH_RING_ALLOCATED;
-	}
-	cancel_delayed_work_sync(&path->tx_poll_work);
-	cancel_delayed_work_sync(&path->rx_supp_poll_work);
-
-	if (tunnel_enabled) {
-		tb_xdomain_disable_paths(xd, path->local_transmit_path,
-					 path->local_tx_hop,
-					 path->remote_transmit_path,
-					 path->local_rx_hop);
-		tb_xdomain_release_in_hopid(xd, path->remote_transmit_path);
-		path->remote_transmit_path = -1;
 		path->state = TBV_PATH_RING_ALLOCATED;
 	}
 	if (!tunnel_enabled && path->remote_transmit_path >= 0) {

--- a/kernel/peer.c
+++ b/kernel/peer.c
@@ -3,10 +3,44 @@
 #define pr_fmt(fmt) "thunderbolt_ibverbs: " fmt
 
 #include <linux/errno.h>
+#include <linux/moduleparam.h>
+#include <linux/pci.h>
 #include <linux/slab.h>
 #include <linux/thunderbolt.h>
 
 #include "tbv.h"
+
+#define TBV_NATIVE_E2E_AUTO	(-1)
+
+static int native_e2e = TBV_NATIVE_E2E_AUTO;
+module_param(native_e2e, int, 0444);
+MODULE_PARM_DESC(native_e2e,
+		 "Native Linux data ring E2E mode: -1 auto, 0 off, 1 on");
+
+static bool tbv_native_e2e_auto_enabled(const struct tbv_peer *peer)
+{
+	const struct tb_xdomain *xd = peer ? peer->xd : NULL;
+	struct device *dev;
+	struct pci_dev *pdev;
+
+	if (!xd || !xd->tb)
+		return true;
+
+	dev = xd->tb->dev.parent;
+	if (!dev || !dev_is_pci(dev))
+		return true;
+
+	pdev = to_pci_dev(dev);
+	return pdev->vendor != PCI_VENDOR_ID_AMD;
+}
+
+static bool tbv_native_e2e_enabled(const struct tbv_peer *peer)
+{
+	if (native_e2e >= 0)
+		return native_e2e > 0;
+
+	return tbv_native_e2e_auto_enabled(peer);
+}
 
 static bool tbv_peer_matches(const struct tbv_peer *peer,
 			     enum tbv_backend_type backend,
@@ -205,12 +239,13 @@ struct tbv_rail *tbv_peer_add_rail(struct tbv_peer *peer,
 	rail->native_remote_ready = false;
 	tbv_native_control_init_rail(rail, peer);
 	tbv_path_default_config(peer->backend, &path_cfg);
-	if (peer->backend == TBV_BACKEND_NATIVE) {
+	if (peer->backend == TBV_BACKEND_NATIVE &&
+	    tbv_native_e2e_enabled(peer)) {
 		/*
-		 * Native rails only bind to Linux peers.  Even in mixed mode the
-		 * Mac-facing wire format is handled by the separate Apple
-		 * backend, so native can keep the hardware E2E delivery contract
-		 * needed for RC semantics.
+		 * E2E is hardware flow control only; it does not retransmit
+		 * lost frames. In auto mode AMD NHI uses the software data
+		 * credit scheme alone because Strix Halo has reproduced TX
+		 * completion wedges with multiple native E2E rings active.
 		 */
 		path_cfg.tx_flags |= RING_FLAG_E2E;
 		path_cfg.rx_flags |= RING_FLAG_E2E;

--- a/kernel/service.c
+++ b/kernel/service.c
@@ -135,21 +135,21 @@ static bool tbv_service_backend_data_enabled(const struct tbv_state *state,
 	return state->native_data;
 }
 
-static bool tbv_service_tbnet_neighbor_ready(struct tbv_state *state,
-					     const struct tb_xdomain *xd)
+static bool tbv_service_tbnet_path_ready(struct tbv_state *state,
+					 const struct tb_xdomain *xd)
 {
 	if (state->cfg.tbnet_identity != TBV_TBNET_ID_MINIMAL_PACKET)
 		return true;
 
-	return tbv_tbnet_minimal_neighbor_ready(&state->tbnet_identity,
-						xd ? xd->remote_uuid : NULL);
+	return tbv_tbnet_minimal_path_ready(&state->tbnet_identity,
+					    xd ? xd->remote_uuid : NULL);
 }
 
-static bool tbv_service_should_defer_apple_tunnel(struct tbv_state *state,
-						  const struct tb_xdomain *xd)
+static bool tbv_service_should_defer_apple_rail(struct tbv_state *state,
+						const struct tb_xdomain *xd)
 {
-	return state->apple_tunnels_wait_tbnet &&
-	       !tbv_service_tbnet_neighbor_ready(state, xd);
+	return state->apple_rails_wait_tbnet &&
+	       !tbv_service_tbnet_path_ready(state, xd);
 }
 
 static bool tbv_service_has_pending_apple_rail_locked(struct tbv_state *state)
@@ -164,42 +164,75 @@ static bool tbv_service_has_pending_apple_rail_locked(struct tbv_state *state)
 
 		list_for_each_entry(rail, &peer->rails, node)
 			if (!rail->removing &&
-			    rail->path.state == TBV_PATH_RING_STARTED)
+			    !READ_ONCE(rail->ibdev) &&
+			    !READ_ONCE(rail->ibdev_register_failed) &&
+			    !READ_ONCE(rail->ibdev_register_deferred) &&
+			    tbv_rail_apple_service_ready(rail))
 				return true;
 	}
 
 	return false;
 }
 
-static void tbv_service_refresh_apple_tunnels_pending(struct tbv_state *state)
+static void tbv_service_refresh_apple_rails_pending(struct tbv_state *state)
 {
 	mutex_lock(&state->lock);
-	state->apple_tunnels_pending =
+	state->apple_rails_pending =
 		tbv_service_has_pending_apple_rail_locked(state);
 	mutex_unlock(&state->lock);
 }
 
-static int tbv_service_enable_apple_tunnel(struct tbv_rail *rail)
+static int tbv_service_enable_apple_rail_tunnel(struct tbv_rail *rail)
+{
+	struct tbv_peer *peer = rail->peer;
+	struct tbv_state *state = peer ? peer->state : NULL;
+	bool enable = false;
+	int ret = 0;
+
+	if (!peer || !state || !peer->xd)
+		return -ENODEV;
+
+	mutex_lock(&peer->control_lock);
+	mutex_lock(&state->lock);
+	if (rail->removing) {
+		ret = -ENODEV;
+	} else if (rail->path.state == TBV_PATH_TUNNEL_ENABLED) {
+		ret = 0;
+	} else if (rail->path.state == TBV_PATH_RING_STARTED) {
+		enable = true;
+	} else {
+		ret = -ENOTCONN;
+	}
+	mutex_unlock(&state->lock);
+
+	if (enable) {
+		ret = tbv_path_enable_tunnel(&rail->path, peer->xd,
+					     rail->path.cfg.receive_path);
+		if (!ret)
+			pr_info("enabled Apple data path service route=0x%llx tx_path=%d rx_path=%d tx_hop=%d rx_hop=%d\n",
+				peer->xd->route, rail->path.local_transmit_path,
+				rail->path.remote_transmit_path,
+				rail->path.local_tx_hop, rail->path.local_rx_hop);
+	}
+	mutex_unlock(&peer->control_lock);
+
+	return ret;
+}
+
+static int tbv_service_publish_apple_rail(struct tbv_rail *rail)
 {
 	struct tbv_peer *peer = rail->peer;
 	int ret;
 
-	ret = tbv_path_enable_tunnel(&rail->path, peer->xd,
-				     rail->path.cfg.receive_path);
+	ret = tbv_service_enable_apple_rail_tunnel(rail);
 	if (ret)
 		return ret;
 
-	pr_info("enabled Apple data path service route=0x%llx tx_path=%d rx_path=%d tx_hop=%d rx_hop=%d\n",
+	pr_info("publishing Apple data service route=0x%llx tx_path=%d rx_path=%d tx_hop=%d rx_hop=%d state=%s\n",
 		peer->xd->route, rail->path.local_transmit_path,
 		rail->path.remote_transmit_path, rail->path.local_tx_hop,
-		rail->path.local_rx_hop);
-	/*
-	 * Apple rails have no separate native HELLO/READY; the tunnel coming
-	 * up IS the data-ready edge. Publish here while we still hold a
-	 * stable reference to rail.
-	 */
-	tbv_ibdev_rail_event(peer->state, rail, true);
-	return 0;
+		rail->path.local_rx_hop, tbv_path_state_name(rail->path.state));
+	return tbv_ibdev_rail_event(peer->state, rail, true);
 }
 
 static struct tbv_rail *
@@ -217,29 +250,32 @@ tbv_service_next_pending_apple_rail(struct tbv_state *state)
 
 		list_for_each_entry(rail, &peer->rails, node) {
 			if (rail->removing ||
-			    rail->path.state != TBV_PATH_RING_STARTED)
+			    READ_ONCE(rail->ibdev) ||
+			    READ_ONCE(rail->ibdev_register_failed) ||
+			    READ_ONCE(rail->ibdev_register_deferred) ||
+			    !tbv_rail_apple_service_ready(rail))
 				continue;
 			pending = true;
-			if (!tbv_service_tbnet_neighbor_ready(state, peer->xd))
+			if (!tbv_service_tbnet_path_ready(state, peer->xd))
 				continue;
 			refcount_inc(&rail->refcnt);
 			mutex_unlock(&state->lock);
 			return rail;
 		}
 	}
-	state->apple_tunnels_pending = pending;
+	state->apple_rails_pending = pending;
 	mutex_unlock(&state->lock);
 	return NULL;
 }
 
-static void tbv_service_apple_tunnel_work(struct work_struct *work)
+static void tbv_service_apple_rail_work(struct work_struct *work)
 {
 	struct tbv_state *state =
-		container_of(work, struct tbv_state, apple_tunnel_work);
+		container_of(work, struct tbv_state, apple_rail_work);
 
 	if (!state->services_registered || !state->enable_tunnels)
 		return;
-	if (!tbv_service_tbnet_neighbor_ready(state, NULL))
+	if (!tbv_service_tbnet_path_ready(state, NULL))
 		return;
 
 	for (;;) {
@@ -250,11 +286,11 @@ static void tbv_service_apple_tunnel_work(struct work_struct *work)
 		if (!rail)
 			return;
 
-		ret = tbv_service_enable_apple_tunnel(rail);
+		ret = tbv_service_publish_apple_rail(rail);
 		if (ret) {
 			struct tbv_peer *peer = rail->peer;
 
-			pr_warn("failed to enable deferred Apple data path peer=%u route=0x%llx rail=0x%x state=%s ret=%d\n",
+			pr_warn("failed to publish deferred Apple data service peer=%u route=0x%llx rail=0x%x state=%s ret=%d\n",
 				peer->peer_id, peer->xd->route,
 				rail->rail_id,
 				tbv_path_state_name(rail->path.state), ret);
@@ -272,26 +308,33 @@ void tbv_services_tbnet_identity_ready(struct tbv_tbnet_identity *identity)
 
 	if (!state || identity != &state->tbnet_identity)
 		return;
-	if (!state->services_registered || !state->apple_tunnels_wait_tbnet)
+	if (!state->services_registered || !state->apple_rails_wait_tbnet)
 		return;
-	if (!tbv_service_tbnet_neighbor_ready(state, NULL))
+	if (!tbv_service_tbnet_path_ready(state, NULL))
 		return;
 
-	queue_work(system_long_wq, &state->apple_tunnel_work);
+	queue_work(system_long_wq, &state->apple_rail_work);
 }
 
-static bool tbv_service_apple_xdomain_allowed(const struct tbv_state *state,
-					      const struct tb_xdomain *xd)
+static bool tbv_service_apple_xdomain_allowed(const struct tb_xdomain *xd)
 {
 	const char *vendor = xd && xd->vendor_name ? xd->vendor_name : NULL;
 
-	if (state->cfg.profile != TBV_PROFILE_MIXED)
-		return true;
-
+	/*
+	 * FA57 is an Apple interop backend, not the Linux peer protocol. Linux
+	 * peers advertise and negotiate the native services; binding their AD key
+	 * here creates a second, weaker transport path to the same machine.
+	 */
 	if (vendor && !strcmp(vendor, "Apple Inc."))
 		return true;
 
-	pr_info("skipping Apple AD/FA57 service from non-Apple peer vendor='%s' in mixed profile\n",
+	if (!vendor) {
+		pr_warn("allowing Apple AD/FA57 service route=0x%llx with unknown peer vendor\n",
+			xd ? xd->route : 0);
+		return true;
+	}
+
+	pr_info("skipping Apple AD/FA57 service from non-Apple peer vendor='%s'\n",
 		vendor ?: "<unknown>");
 	return false;
 }
@@ -345,7 +388,7 @@ static int tbv_service_probe(struct tb_service *svc,
 		return -ENODEV;
 
 	if (backend == TBV_BACKEND_APPLE &&
-	    !tbv_service_apple_xdomain_allowed(tbv_service_state, xd))
+	    !tbv_service_apple_xdomain_allowed(xd))
 		return -ENODEV;
 
 	if (backend == TBV_BACKEND_NATIVE &&
@@ -376,13 +419,14 @@ static int tbv_service_probe(struct tb_service *svc,
 	if (tbv_service_state->allocate_rings &&
 	    tbv_service_backend_data_enabled(tbv_service_state, backend)) {
 		ret = tbv_path_alloc_rings(&rail->path, xd, -1);
-		if (ret) {
+		if (ret)
 			goto err_remove_rail;
-		}
+
 		if (!rail->path.tx_ring || !rail->path.rx_ring) {
 			ret = -EIO;
 			goto err_remove_rail;
 		}
+
 		pr_info("allocated rings service id=%d native_lane=%u tx_hop=%d rx_hop=%d out_hop=%d\n",
 			svc->id, backend == TBV_BACKEND_NATIVE ? native_lane : 0,
 			rail->path.tx_ring->hop,
@@ -391,9 +435,9 @@ static int tbv_service_probe(struct tb_service *svc,
 
 		if (tbv_service_state->start_rings) {
 			ret = tbv_path_start_rings(&rail->path);
-			if (ret) {
+			if (ret)
 				goto err_remove_rail;
-			}
+
 			pr_info("started rings service id=%d native_lane=%u tx_hop=%d rx_hop=%d\n",
 				svc->id,
 				backend == TBV_BACKEND_NATIVE ? native_lane : 0,
@@ -401,17 +445,17 @@ static int tbv_service_probe(struct tb_service *svc,
 				rail->path.rx_ring->hop);
 
 			if (backend == TBV_BACKEND_NATIVE &&
-			    tbv_service_state->negotiate_native)
+			    tbv_service_state->negotiate_native) {
 				tbv_native_control_queue_rail(tbv_service_state,
 							      rail);
-			else if (backend == TBV_BACKEND_APPLE &&
-				 tbv_service_state->enable_tunnels) {
-				if (tbv_service_should_defer_apple_tunnel(tbv_service_state, xd)) {
-					tbv_service_state->apple_tunnels_pending = true;
-					pr_info("deferring Apple data path service id=%d route=0x%llx until TBnet neighbor is proven\n",
+			} else if (backend == TBV_BACKEND_APPLE &&
+				   tbv_service_state->enable_tunnels) {
+				if (tbv_service_should_defer_apple_rail(tbv_service_state, xd)) {
+					tbv_service_state->apple_rails_pending = true;
+					pr_info("deferring Apple data service id=%d route=0x%llx until ThunderboltIP packet path is active\n",
 						svc->id, xd->route);
 				} else {
-					ret = tbv_service_enable_apple_tunnel(rail);
+					ret = tbv_service_publish_apple_rail(rail);
 					if (ret)
 						goto err_remove_rail;
 				}
@@ -432,7 +476,7 @@ static int tbv_service_probe(struct tb_service *svc,
 err_remove_rail:
 	tbv_peer_remove_rail(rail);
 	if (backend == TBV_BACKEND_APPLE)
-		tbv_service_refresh_apple_tunnels_pending(tbv_service_state);
+		tbv_service_refresh_apple_rails_pending(tbv_service_state);
 err_put_peer:
 	tbv_peer_put(tbv_service_state, peer);
 err_free_binding:
@@ -449,7 +493,7 @@ static void tbv_service_remove(struct tb_service *svc)
 
 		tbv_peer_remove_rail(binding->rail);
 		if (backend == TBV_BACKEND_APPLE)
-			tbv_service_refresh_apple_tunnels_pending(tbv_service_state);
+			tbv_service_refresh_apple_rails_pending(tbv_service_state);
 		tbv_peer_put(tbv_service_state, binding->peer);
 	}
 	tb_service_set_drvdata(svc, NULL);
@@ -602,15 +646,16 @@ int tbv_services_start(struct tbv_state *state, bool bind_services,
 	state->negotiate_native = service_cfg->negotiate_native;
 	state->enable_tunnels = service_cfg->enable_tunnels;
 	/*
-	 * Minimal TBnet identity is still advertised so macOS sees a normal
-	 * ThunderboltIP-capable peer, but Apple AD/FA57 data tunnels must not
-	 * depend on macOS bringing the matching IP interface up. macOS can keep
-	 * the RDMA port usable while the enX side is inactive or has not
-	 * exchanged neighbor traffic yet.
+	 * Apple's RDMA interface is layered on an AppleThunderboltIP-backed
+	 * IOEthernetInterface. In minimal-packet mode, publish the Apple verbs rail
+	 * only after reciprocal LOGIN/LOGIN_RESPONSE and ThunderboltIP path
+	 * programming. FA57 DMA tunnel setup is part of rail publication, so
+	 * userspace cannot create a QP on an unprogrammed Apple data path.
 	 */
-	state->apple_tunnels_wait_tbnet = false;
-	state->apple_tunnels_pending = false;
-	INIT_WORK(&state->apple_tunnel_work, tbv_service_apple_tunnel_work);
+	state->apple_rails_wait_tbnet =
+		state->cfg.tbnet_identity == TBV_TBNET_ID_MINIMAL_PACKET;
+	state->apple_rails_pending = false;
+	INIT_WORK(&state->apple_rail_work, tbv_service_apple_rail_work);
 
 	if (!bind_services) {
 		pr_info("Thunderbolt service binding disabled\n");
@@ -671,8 +716,8 @@ void tbv_services_stop(struct tbv_state *state)
 		tb_unregister_service_driver(&tbv_service_driver);
 		state->services_registered = false;
 	}
-	cancel_work_sync(&state->apple_tunnel_work);
-	state->apple_tunnels_pending = false;
+	cancel_work_sync(&state->apple_rail_work);
+	state->apple_rails_pending = false;
 
 	tbv_tbnet_minimal_stop(&state->tbnet_identity);
 	tbv_native_control_stop(state);

--- a/kernel/tbnet_identity.c
+++ b/kernel/tbnet_identity.c
@@ -299,7 +299,7 @@ int tbv_tbip_parse_status(const void *buf, size_t size,
 
 	if (!result)
 		return -EINVAL;
-	if (size < sizeof(*msg))
+	if (!buf || size < sizeof(*msg))
 		return -EINVAL;
 
 	memset(result, 0, sizeof(*result));

--- a/kernel/tbnet_minimal.c
+++ b/kernel/tbnet_minimal.c
@@ -170,6 +170,28 @@ tbv_tbnet_minimal_ctrl_matches(const struct tbv_tbnet_minimal_session *session,
 	       uuid_equal(&ctrl->target_uuid, session->xd->local_uuid);
 }
 
+static bool
+tbv_tbnet_minimal_response_matches(
+	const struct tbv_tbnet_minimal_session *session,
+	const struct tbv_tbip_control *request,
+	const struct tbv_tbip_control *response)
+{
+	/*
+	 * macOS echoes command_id in direct responses but advances sequence from
+	 * its own control stream. command_id identifies the request; sequence is
+	 * only meaningful for the sender's XDomain control flow.
+	 */
+	return tbv_tbnet_minimal_ctrl_matches(session, response) &&
+	       response->command_id == request->command_id;
+}
+
+static bool
+tbv_tbnet_minimal_status_matches(const struct tbv_tbnet_minimal_session *session,
+				 const struct tbv_tbip_control *response)
+{
+	return tbv_tbnet_minimal_ctrl_matches(session, response);
+}
+
 static u32 tbv_tbnet_minimal_frame_len(const struct ring_frame *frame)
 {
 	return frame->size ? frame->size : (u32)TBV_TBNET_MIN_FRAME_SIZE;
@@ -485,6 +507,29 @@ out:
 	return ready;
 }
 
+bool tbv_tbnet_minimal_path_ready(struct tbv_tbnet_identity *identity,
+				  const uuid_t *remote_uuid)
+{
+	struct tbv_tbnet_minimal_session *session;
+	bool ready = false;
+
+	if (identity->mode != TBV_TBNET_ID_MINIMAL_PACKET)
+		return false;
+
+	mutex_lock(&identity->lock);
+	list_for_each_entry(session, &identity->minimal_sessions, node) {
+		if (remote_uuid &&
+		    !uuid_equal(session->xd->remote_uuid, remote_uuid))
+			continue;
+		if (!READ_ONCE(session->path_enabled))
+			continue;
+		ready = true;
+		break;
+	}
+	mutex_unlock(&identity->lock);
+	return ready;
+}
+
 void tbv_tbnet_minimal_clear_neighbors_locked(struct tbv_tbnet_identity *identity)
 {
 	struct tbv_tbnet_minimal_session *session;
@@ -503,7 +548,8 @@ static void tbv_tbnet_minimal_recompute_state(struct tbv_tbnet_identity *identit
 
 	mutex_lock(&identity->lock);
 	tbv_tbnet_minimal_recompute_state_locked(identity);
-	ready = identity->state & TBV_TBNET_ID_STATE_NEIGHBOR_READY;
+	ready = identity->state & (TBV_TBNET_ID_STATE_PACKET_PATH_ACTIVE |
+				   TBV_TBNET_ID_STATE_NEIGHBOR_READY);
 	mutex_unlock(&identity->lock);
 
 	if (ready)
@@ -895,7 +941,6 @@ static void tbv_tbnet_minimal_teardown_path(struct tbv_tbnet_minimal_session *s)
 	}
 	s->login_sent = false;
 	s->login_received = false;
-	s->logout_reset_sent = false;
 	s->login_retries = 0;
 	mutex_unlock(&s->lock);
 
@@ -1005,6 +1050,11 @@ static void tbv_tbnet_minimal_login_work(struct work_struct *work)
 	mutex_unlock(&session->lock);
 
 	if (need_reset) {
+		/*
+		 * A reload can leave macOS with a half-open ThunderboltIP
+		 * connection from the previous module instance. Clear that
+		 * protocol state before starting this session's LOGIN exchange.
+		 */
 		ret = tbv_tbnet_minimal_send_logout_request(session, sequence);
 		if (ret && ret != -ETIMEDOUT && ret != -ENODEV)
 			pr_debug("minimal TBnet logout reset route=0x%llx ret=%d\n",
@@ -1040,7 +1090,8 @@ static void tbv_tbnet_minimal_login_work(struct work_struct *work)
 		ret = tbv_tbip_parse_login_response(reply, sizeof(reply),
 						    &response);
 	if (!ret &&
-	    (!tbv_tbnet_minimal_ctrl_matches(session, &response.ctrl) ||
+	    (!tbv_tbnet_minimal_response_matches(session, &params.ctrl,
+						 &response.ctrl) ||
 	     response.status)) {
 		ret = -EPROTO;
 	}
@@ -1070,6 +1121,7 @@ static void tbv_tbnet_minimal_login_work(struct work_struct *work)
 			session->xd->route);
 	}
 	mutex_unlock(&session->lock);
+	tbv_services_tbnet_identity_ready(session->identity);
 	queue_work(system_long_wq, &session->connected_work);
 	if (retry_later)
 		queue_delayed_work(system_long_wq, &session->login_work,
@@ -1147,7 +1199,7 @@ tbv_tbnet_minimal_send_logout_request(struct tbv_tbnet_minimal_session *session,
 	if (!ret)
 		ret = tbv_tbip_parse_status(reply, sizeof(reply), &status);
 	if (!ret &&
-	    (!tbv_tbnet_minimal_ctrl_matches(session, &status.ctrl) ||
+	    (!tbv_tbnet_minimal_status_matches(session, &status.ctrl) ||
 	     status.status)) {
 		ret = -EPROTO;
 	}
@@ -1157,6 +1209,31 @@ tbv_tbnet_minimal_send_logout_request(struct tbv_tbnet_minimal_session *session,
 	}
 
 	return ret;
+}
+
+static void
+tbv_tbnet_minimal_send_shutdown_logout(struct tbv_tbnet_minimal_session *session)
+{
+	bool should_logout;
+	u8 sequence;
+	int ret;
+
+	mutex_lock(&session->lock);
+	should_logout = session->login_sent || session->login_received ||
+			session->path_enabled;
+	sequence = (u8)(atomic_read(&session->command_id) & 0x3);
+	mutex_unlock(&session->lock);
+
+	if (!should_logout)
+		return;
+
+	ret = tbv_tbnet_minimal_send_logout_request(session, sequence);
+	if (ret)
+		pr_info("minimal TBnet shutdown logout route=0x%llx failed: %d\n",
+			session->xd->route, ret);
+	else
+		pr_info("minimal TBnet shutdown logout route=0x%llx acknowledged\n",
+			session->xd->route);
 }
 
 static int tbv_tbnet_minimal_handle_packet_common(
@@ -1202,6 +1279,7 @@ static int tbv_tbnet_minimal_handle_packet_common(
 						   &session->login_work, 0);
 		}
 		mutex_unlock(&session->lock);
+		tbv_services_tbnet_identity_ready(session->identity);
 		queue_work(system_long_wq, &session->connected_work);
 		return 1;
 
@@ -1347,6 +1425,9 @@ static int tbv_tbnet_minimal_probe(struct tb_service *svc,
 #else
 	session->handler.callback = tbv_tbnet_minimal_handle_packet;
 #endif
+#ifdef TB_PROTOCOL_HANDLER_HAS_OWNER
+	session->handler.owner = THIS_MODULE;
+#endif
 	session->handler.data = session;
 	ret = tb_register_protocol_handler(&session->handler);
 	if (ret)
@@ -1359,8 +1440,7 @@ static int tbv_tbnet_minimal_probe(struct tb_service *svc,
 	mutex_unlock(&identity->lock);
 
 	tb_service_set_drvdata(svc, session);
-	queue_delayed_work(system_long_wq, &session->login_work,
-			   msecs_to_jiffies(1000));
+	queue_delayed_work(system_long_wq, &session->login_work, 0);
 	pr_info("bound minimal TBnet service id=%d route=0x%llx tx_path=%d mac=%pM prtcstns=0x%x\n",
 		svc->id, xd->route, session->local_transmit_path,
 		session->mac, svc->prtcstns);
@@ -1408,15 +1488,16 @@ tbv_tbnet_minimal_destroy_session(struct tbv_tbnet_minimal_session *session)
 	session->removing = true;
 	mutex_unlock(&session->lock);
 
+	if (session->handler_registered) {
+		tb_unregister_protocol_handler(&session->handler);
+		session->handler_registered = false;
+	}
 	cancel_delayed_work_sync(&session->login_work);
 	cancel_work_sync(&session->connected_work);
 	cancel_work_sync(&session->disconnect_work);
 	cancel_work_sync(&session->rx_work);
 	cancel_delayed_work_sync(&session->tx_poll_work);
-	if (session->handler_registered) {
-		tb_unregister_protocol_handler(&session->handler);
-		session->handler_registered = false;
-	}
+	tbv_tbnet_minimal_send_shutdown_logout(session);
 	tbv_tbnet_minimal_teardown_path(session);
 
 	mutex_lock(&identity->lock);
@@ -1457,6 +1538,11 @@ int tbv_tbnet_minimal_start(struct tbv_tbnet_identity *identity)
 {
 	u32 prtcstns = TBV_TBNET_MATCH_FRAGS_ID | TBV_TBNET_64K_FRAMES;
 	int ret;
+
+#ifndef TB_PROTOCOL_HANDLER_UNREGISTER_DRAINS
+	pr_err("tbnet_identity=minimal_packet requires XDomain protocol handler unregister-drain support\n");
+	return -EOPNOTSUPP;
+#endif
 
 	if (identity->minimal_started)
 		return 0;

--- a/kernel/tbv.h
+++ b/kernel/tbv.h
@@ -201,6 +201,7 @@ struct tbv_path {
 	atomic64_t data_tx_credit_stalls;
 	atomic64_t data_tx_credit_received;
 	atomic64_t data_rx_completed;
+	atomic64_t data_rx_canceled;
 	atomic64_t data_rx_credit_sent;
 	atomic64_t data_rx_credit_send_error;
 	atomic64_t data_rx_repost_failed;
@@ -249,6 +250,7 @@ struct tbv_rail {
 	 */
 	struct tbv_ibdev *ibdev;
 	atomic_t native_qp_bind_count;
+	u32 apple_tunnel_qps;
 	u32 rail_id;
 	u32 link_speed;
 	u32 link_width;
@@ -319,6 +321,14 @@ static inline bool tbv_rail_data_ready(const struct tbv_rail *rail)
 static inline bool tbv_rail_apple_data_ready(const struct tbv_rail *rail)
 {
 	return rail && rail->path.state == TBV_PATH_TUNNEL_ENABLED;
+}
+
+static inline bool tbv_rail_apple_service_ready(const struct tbv_rail *rail)
+{
+	if (!rail)
+		return false;
+	return rail->path.state == TBV_PATH_RING_STARTED ||
+	       rail->path.state == TBV_PATH_TUNNEL_ENABLED;
 }
 
 struct tbv_tbnet_identity {
@@ -450,9 +460,9 @@ struct tbv_state {
 	bool native_control_registered;
 	bool native_control_source_aware;
 	bool native_legacy_multicable_warned;
-	bool apple_tunnels_wait_tbnet;
-	bool apple_tunnels_pending;
-	struct work_struct apple_tunnel_work;
+	bool apple_rails_wait_tbnet;
+	bool apple_rails_pending;
+	struct work_struct apple_rail_work;
 	struct workqueue_struct *workqueue;
 	struct notifier_block ibdev_netdev_nb;
 	atomic_t verbs_ucontexts;
@@ -496,11 +506,21 @@ struct tbv_state {
 	atomic64_t data_tx_credit_stalls;
 	atomic64_t data_tx_credit_received;
 	atomic64_t data_rx_completed;
+	atomic64_t data_rx_canceled;
 	atomic64_t data_rx_credit_sent;
 	atomic64_t data_rx_credit_send_error;
 	atomic64_t data_rx_repost_failed;
 	atomic64_t data_rx_bad_frame;
 	atomic64_t data_rx_bad_header;
+	atomic64_t data_rx_bad_header_parse;
+	atomic64_t data_rx_bad_header_len;
+	atomic64_t data_rx_bad_header_path_credit;
+	atomic64_t data_rx_bad_header_opcode;
+	atomic64_t data_rx_bad_header_recv_credit;
+	atomic64_t data_rx_bad_header_ack;
+	atomic64_t data_rx_bad_header_write;
+	atomic64_t data_rx_bad_header_read_req;
+	atomic64_t data_rx_bad_header_mad;
 	atomic64_t data_rx_send;
 	atomic64_t data_rx_op_send;
 	atomic64_t data_rx_op_send_imm;
@@ -572,6 +592,9 @@ struct tbv_state {
 	atomic64_t apple_rx_no_sof_when_idle;
 	atomic64_t apple_rx_eof_without_active;
 	atomic64_t apple_rx_len_overrun;
+	atomic64_t apple_rx_resync_dropped;
+	atomic64_t apple_rx_rail_mismatch;
+	atomic64_t apple_rx_cq_overflow;
 	atomic64_t data_cq_overflow;
 	atomic64_t native_legacy_ambiguous_limited;
 	struct xarray verbs_mrs_xa;
@@ -693,6 +716,8 @@ void tbv_tbnet_minimal_stop(struct tbv_tbnet_identity *identity);
 void tbv_tbnet_minimal_recompute_state_locked(struct tbv_tbnet_identity *identity);
 bool tbv_tbnet_minimal_neighbor_ready(struct tbv_tbnet_identity *identity,
 				      const uuid_t *remote_uuid);
+bool tbv_tbnet_minimal_path_ready(struct tbv_tbnet_identity *identity,
+				  const uuid_t *remote_uuid);
 void tbv_tbnet_minimal_clear_neighbors_locked(struct tbv_tbnet_identity *identity);
 void tbv_tbnet_minimal_debugfs_show(struct seq_file *s,
 				    struct tbv_tbnet_identity *identity);
@@ -748,6 +773,7 @@ int tbv_path_alloc_rings(struct tbv_path *path, struct tb_xdomain *xd,
 int tbv_path_start_rings(struct tbv_path *path);
 int tbv_path_enable_tunnel(struct tbv_path *path, struct tb_xdomain *xd,
 			   int remote_transmit_path);
+int tbv_path_disable_tunnel(struct tbv_path *path, struct tb_xdomain *xd);
 void tbv_path_set_remote_rx_capacity(struct tbv_path *path, u32 rx_ring_size);
 void tbv_path_add_remote_rx_credits(struct tbv_path *path, u32 credits);
 int tbv_path_reserve_data(struct tbv_path *path, u32 frames);

--- a/lib/bench/perftest.nix
+++ b/lib/bench/perftest.nix
@@ -132,6 +132,9 @@ let
     # Completion path: CQ batching / polling.
     (mkBwOdd  { tag = "cqmod16";     bin = "ib_write_bw"; size = 1024;  opts = { "cq-mod" = 16; }; })
     (mkBwOdd  { tag = "cqepoll64";   bin = "ib_write_bw"; size = 65536; qp = 4; opts = { cqe_poll = 64; }; })
+    (mkBwOdd  { tag = "txd16";       bin = "ib_write_bw"; size = 65536; qp = 8; opts = { "tx-depth" = 16; }; })
+    (mkBwOdd  { tag = "txd32";       bin = "ib_write_bw"; size = 65536; qp = 8; opts = { "tx-depth" = 32; }; })
+    (mkBwOdd  { tag = "txd64";       bin = "ib_write_bw"; size = 65536; qp = 8; opts = { "tx-depth" = 64; }; })
 
     # Timing / reporting: warmup, lat gap, CPU%.
     (mkLatOdd { tag = "warmup";      bin = "ib_write_lat"; size = 1024; opts = { perform_warm_up = true; }; })

--- a/module.nix
+++ b/module.nix
@@ -117,41 +117,72 @@
         awk -F': *' -v key="$1" '$1 == key { print $2; found=1; exit } END { if (!found) exit 1 }' "$summary"
       }
 
-      if ! grep -q '^thunderbolt_ibverbs ' /proc/modules; then
-        fail "module thunderbolt_ibverbs is not loaded"
-      fi
-
       deadline=$((SECONDS + timeout))
+      timed_out() {
+        [ "$SECONDS" -ge "$deadline" ]
+      }
+
+      while ! grep -q '^thunderbolt_ibverbs ' /proc/modules; do
+        if timed_out; then
+          fail "module thunderbolt_ibverbs is not loaded within ''${timeout}s"
+        fi
+        sleep 1
+      done
+
       while [ ! -r "$summary" ]; do
-        if [ "$SECONDS" -ge "$deadline" ]; then
+        if timed_out; then
           fail "debugfs summary did not appear at $summary within ''${timeout}s"
         fi
         sleep 1
       done
 
+      wait_summary_value() {
+        key="$1"
+        expected="$2"
+        label="$3"
+        actual=""
+
+        while true; do
+          actual="$(get_summary "$key" || true)"
+          if [ "$actual" = "$expected" ]; then
+            return 0
+          fi
+          if timed_out; then
+            fail "$label: expected $expected, got ''${actual:-<missing>}"
+          fi
+          sleep 1
+        done
+      }
+
       if [ -n "$expected_profile" ]; then
-        actual_profile="$(get_summary profile || true)"
-        [ "$actual_profile" = "$expected_profile" ] ||
-          fail "profile mismatch: expected $expected_profile, got ''${actual_profile:-<missing>}"
+        wait_summary_value profile "$expected_profile" "profile mismatch"
       fi
 
       if [ -n "$expected_native_control" ]; then
-        actual_native_control="$(get_summary native_control || true)"
-        [ "$actual_native_control" = "$expected_native_control" ] ||
-          fail "native_control mismatch: expected $expected_native_control, got ''${actual_native_control:-<missing>}"
+        wait_summary_value native_control "$expected_native_control" "native_control mismatch"
       fi
 
       if [ "$require_verbs" = "1" ]; then
-        verbs_registered="$(get_summary verbs_registered || true)"
-        [ "$verbs_registered" = "1" ] ||
-          fail "verbs device is not registered"
+        wait_summary_value verbs_registered 1 "verbs device is not registered"
       fi
 
       if [ -n "$min_ready_rails" ]; then
-        [ -r "$peers" ] || fail "debugfs peers file is missing at $peers"
-        ready_rails="$(grep -o 'data_ready=1' "$peers" | wc -l | tr -d ' ')"
-        [ "$ready_rails" -ge "$min_ready_rails" ] ||
-          fail "ready rail count too low: expected >= $min_ready_rails, got $ready_rails"
+        ready_rails=0
+        while true; do
+          if [ -r "$peers" ]; then
+            ready_rails="$( { grep -o 'data_ready=1' "$peers" || true; } | wc -l | tr -d ' ')"
+            if [ "$ready_rails" -ge "$min_ready_rails" ]; then
+              break
+            fi
+          fi
+          if timed_out; then
+            if [ ! -r "$peers" ]; then
+              fail "debugfs peers file is missing at $peers within ''${timeout}s"
+            fi
+            fail "ready rail count too low: expected >= $min_ready_rails, got $ready_rails"
+          fi
+          sleep 1
+        done
       fi
 
       if [ -n "$expected_speed" ]; then

--- a/nix/bench-tools.nix
+++ b/nix/bench-tools.nix
@@ -33,6 +33,7 @@ let
     "tbv_perftest_runner.py"
     "tbv_rdma_sweep.py"
     "tbv_uc_stress.py"
+    "tbv_vllm_smoke.sh"
   ];
 
   cPrograms = if isDarwin then darwinPrograms else linuxPrograms;

--- a/tools/tbv-target-module.sh
+++ b/tools/tbv-target-module.sh
@@ -16,6 +16,9 @@ kernel.
 Options:
   --nixos-config PATH          NixOS config flake, default ../nixos-config.
   --config ATTR                nixosConfigurations attr, default TARGET.
+  --booted-kernel              Build directly against TARGET's currently
+                              booted kernel store derivation, skipping the
+                              NixOS config evaluation.
   --ssh HOST                   SSH host, default TARGET.
   --copy-to STORE             Nix copy destination, default ssh-ng://SSH_HOST.
   --copy                      Copy the verified module closure to TARGET.
@@ -37,6 +40,7 @@ Options:
 Examples:
   tools/tbv-target-module.sh router --nixos-config ../nixos-config
   tools/tbv-target-module.sh router --copy
+  tools/tbv-target-module.sh strix-1 --booted-kernel --reload --options 'profile=linux_perf ...'
   tools/tbv-target-module.sh router --reload --options 'profile=mac_compat ...'
 EOF
 }
@@ -52,7 +56,7 @@ sh_quote() {
 }
 
 abs_dir() {
-	(CDPATH= cd -- "$1" && pwd)
+	(CDPATH=; cd -- "$1" && pwd)
 }
 
 repo_root="$(abs_dir "$(dirname -- "${BASH_SOURCE[0]}")/..")"
@@ -63,6 +67,7 @@ ssh_host=""
 copy_to=""
 copy=0
 reload=0
+booted_kernel=0
 allow_empty_options=0
 allow_kernel_path_mismatch=0
 check_sigs=0
@@ -85,6 +90,9 @@ while (($#)); do
 		shift
 		[[ $# -gt 0 ]] || die "--config requires an attr name"
 		config_attr="$1"
+		;;
+	--booted-kernel)
+		booted_kernel=1
 		;;
 	--ssh)
 		shift
@@ -162,23 +170,38 @@ trap cleanup EXIT
 
 expr="$tmpdir/module.nix"
 kernel_expr="$tmpdir/kernel-path.nix"
-cat >"$expr" <<EOF
-let
-  flake = builtins.getFlake "path:$nixos_config";
-  cfg = (builtins.getAttr "$config_attr" flake.nixosConfigurations).config;
-in
-  cfg.boot.kernelPackages.callPackage $repo_root/nix/module.nix {
-    source = $repo_root;
-  }
-EOF
 
-cat >"$kernel_expr" <<EOF
-let
-  flake = builtins.getFlake "path:$nixos_config";
-  cfg = (builtins.getAttr "$config_attr" flake.nixosConfigurations).config;
-in
-  toString cfg.boot.kernelPackages.kernel
-EOF
+find_booted_kernel_dev() {
+	local kernel_path=$1
+	local drv
+	local output
+	local -a dev_outputs=()
+
+	[[ -n "$kernel_path" ]] || die "remote booted kernel path is empty"
+	[[ -e "$kernel_path" ]] ||
+		die "remote booted kernel path is not present in the local store: $kernel_path"
+
+	drv="$(nix-store -q --deriver "$kernel_path" 2>/dev/null || true)"
+	[[ -n "$drv" && "$drv" != "unknown-deriver" ]] ||
+		die "could not find local deriver for booted kernel $kernel_path"
+
+	while IFS= read -r output; do
+		[[ -n "$output" ]] || continue
+		case "$output" in
+		*-dev)
+			dev_outputs+=("$output")
+			;;
+		esac
+	done < <(nix-store -q --outputs "$drv")
+
+	if [[ "${#dev_outputs[@]}" -ne 1 ]]; then
+		printf 'kernel derivation outputs for %s:\n' "$drv" >&2
+		nix-store -q --outputs "$drv" >&2 || true
+		die "expected exactly one booted-kernel dev output, found ${#dev_outputs[@]}"
+	fi
+
+	printf '%s\n' "${dev_outputs[0]}"
+}
 
 printf '==> Target: %s via ssh %s\n' "$config_attr" "$ssh_host"
 remote_uname="$(ssh "$ssh_host" 'uname -r')"
@@ -189,16 +212,58 @@ if [[ -n "$remote_kernel" ]]; then
 	printf '==> Remote booted kernel: %s\n' "$remote_kernel"
 fi
 
-config_kernel="$(nix eval --impure --raw "${nix_override_args[@]}" --expr "$(<"$kernel_expr")")"
-printf '==> Config kernel: %s\n' "$config_kernel"
-if [[ -n "$remote_kernel" && "$config_kernel" != "$remote_kernel" ]]; then
-	if [[ "$allow_kernel_path_mismatch" != 1 ]]; then
-		die "config kernel does not match remote booted kernel; deploy/reboot the target or pass --allow-kernel-path-mismatch for an explicit ABI-only experiment"
+if [[ "$booted_kernel" == 1 ]]; then
+	booted_kernel_dev="$(find_booted_kernel_dev "$remote_kernel")"
+	printf '==> Booted kernel dev: %s\n' "$booted_kernel_dev"
+	cat >"$expr" <<EOF
+let
+  flake = builtins.getFlake "path:$repo_root";
+  pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+  kernel = {
+    modDirVersion = "$remote_uname";
+    dev = builtins.storePath "$booted_kernel_dev";
+    moduleBuildDependencies = pkgs.linuxPackages.kernel.moduleBuildDependencies;
+  };
+in
+  pkgs.callPackage $repo_root/nix/module.nix {
+    inherit kernel;
+    source = $repo_root;
+  }
+EOF
+else
+	cat >"$expr" <<EOF
+let
+  flake = builtins.getFlake "path:$nixos_config";
+  cfg = (builtins.getAttr "$config_attr" flake.nixosConfigurations).config;
+in
+  cfg.boot.kernelPackages.callPackage $repo_root/nix/module.nix {
+    source = $repo_root;
+  }
+EOF
+
+	cat >"$kernel_expr" <<EOF
+let
+  flake = builtins.getFlake "path:$nixos_config";
+  cfg = (builtins.getAttr "$config_attr" flake.nixosConfigurations).config;
+in
+  toString cfg.boot.kernelPackages.kernel
+EOF
+
+	config_kernel="$(nix eval --impure --raw "${nix_override_args[@]}" --expr "$(<"$kernel_expr")")"
+	printf '==> Config kernel: %s\n' "$config_kernel"
+	if [[ -n "$remote_kernel" && "$config_kernel" != "$remote_kernel" ]]; then
+		if [[ "$allow_kernel_path_mismatch" != 1 ]]; then
+			die "config kernel does not match remote booted kernel; deploy/reboot the target or pass --allow-kernel-path-mismatch for an explicit ABI-only experiment"
+		fi
+		printf 'warning: config kernel path differs from remote booted kernel; continuing by request\n' >&2
 	fi
-	printf 'warning: config kernel path differs from remote booted kernel; continuing by request\n' >&2
 fi
 
-printf '==> Building module for %s\n' "$config_attr"
+if [[ "$booted_kernel" == 1 ]]; then
+	printf '==> Building module for %s booted kernel\n' "$config_attr"
+else
+	printf '==> Building module for %s configured kernel\n' "$config_attr"
+fi
 module_pkg="$(nix build --impure --no-link --print-out-paths "${nix_override_args[@]}" --expr "$(<"$expr")" | tail -n1)"
 [[ -n "$module_pkg" ]] || die "nix build produced no output path"
 
@@ -225,6 +290,7 @@ if [[ "$copy" == 1 ]]; then
 	printf '==> Copying module closure to %s\n' "$copy_to"
 	nix "${copy_args[@]}"
 
+	# shellcheck disable=SC2029 # $module is intentionally expanded locally.
 	remote_module_uname="$(ssh "$ssh_host" "modinfo -F vermagic $(sh_quote "$module") | awk '{print \$1}'")"
 	[[ "$remote_module_uname" == "$remote_uname" ]] ||
 		die "remote copied module vermagic '$remote_module_uname' does not match remote uname '$remote_uname'"
@@ -236,6 +302,7 @@ if [[ "$reload" == 1 ]]; then
 	fi
 	printf '==> Reloading thunderbolt_ibverbs on %s\n' "$ssh_host"
 	printf 'warning: --reload is non-atomic; a remote insmod failure leaves thunderbolt_ibverbs unloaded\n' >&2
+	# shellcheck disable=SC2029 # Module path/options are intentionally expanded locally.
 	ssh "$ssh_host" \
 		"sudo -n env TBV_MODULE=$(sh_quote "$module") TBV_EXPECTED_UNAME=$(sh_quote "$remote_uname") TBV_OPTIONS=$(sh_quote "$module_options") TBV_WAIT_SECS=$(sh_quote "$wait_secs") bash -s" <<'REMOTE'
 set -euo pipefail

--- a/userspace/bench/tbv_perftest_runner.py
+++ b/userspace/bench/tbv_perftest_runner.py
@@ -58,11 +58,21 @@ IMPORTANT_COUNTERS = [
     "data_tx_credit_stalls",
     "data_tx_credit_received",
     "data_rx_completed",
+    "data_rx_canceled",
     "data_rx_credit_sent",
     "data_rx_credit_send_error",
     "data_rx_repost_failed",
     "data_rx_bad_frame",
     "data_rx_bad_header",
+    "data_rx_bad_header_parse",
+    "data_rx_bad_header_len",
+    "data_rx_bad_header_path_credit",
+    "data_rx_bad_header_opcode",
+    "data_rx_bad_header_recv_credit",
+    "data_rx_bad_header_ack",
+    "data_rx_bad_header_write",
+    "data_rx_bad_header_read_req",
+    "data_rx_bad_header_mad",
     "data_rx_send",
     "data_rx_op_send",
     "data_rx_op_send_imm",
@@ -135,6 +145,7 @@ PEER_COUNTERS = [
     "data_tx_credit_stalls",
     "data_tx_credit_received",
     "data_rx_completed",
+    "data_rx_canceled",
     "data_rx_credit_sent",
     "data_rx_credit_send_error",
     "data_rx_repost_failed",
@@ -153,10 +164,20 @@ FATAL_COUNTERS = [
     "data_tx_ack_error",
     "data_tx_ack_send_error",
     "data_tx_read_ack_error",
+    "data_rx_canceled",
     "data_rx_credit_send_error",
     "data_rx_repost_failed",
     "data_rx_bad_frame",
     "data_rx_bad_header",
+    "data_rx_bad_header_parse",
+    "data_rx_bad_header_len",
+    "data_rx_bad_header_path_credit",
+    "data_rx_bad_header_opcode",
+    "data_rx_bad_header_recv_credit",
+    "data_rx_bad_header_ack",
+    "data_rx_bad_header_write",
+    "data_rx_bad_header_read_req",
+    "data_rx_bad_header_mad",
     "data_rx_ack_miss",
     "data_rx_ack_history_miss",
     "data_rx_read_ack_error",
@@ -191,6 +212,11 @@ FATAL_COUNTERS = [
     "data_cq_overflow",
 ]
 
+APPLE_RDMA_DEV_PREFIX = "rdma_en"
+APPLE_UC_GID_INDEX = 1
+APPLE_UC_MTU = 1024
+APPLE_UC_QUEUE_DEPTH = 32
+
 CSV_FIELDS = [
     "timestamp_utc",
     "plan",
@@ -210,6 +236,10 @@ CSV_FIELDS = [
     "iommu",
     "direction",
     "dev",
+    "server_dev",
+    "client_dev",
+    "server_data_addr",
+    "client_data_addr",
     "gid_index",
     "port",
     "status",
@@ -220,6 +250,7 @@ CSV_FIELDS = [
     "tx_depth",
     "rx_depth",
     "connection",
+    "mtu",
     "bidirectional",
     "bw_peak_gbps",
     "bw_avg_gbps",
@@ -272,6 +303,8 @@ PERFTEST_DARWIN = os.environ.get("TBV_PERFTEST_DARWIN", "")
 
 # Set once per run by detect_systems(); maps hostname -> "Linux" / "Darwin".
 HOST_SYSTEM: dict[str, str] = {}
+SSH_CONFIG = ""
+SSH_OPTIONS: list[str] = []
 
 
 def perftest_for(host: str) -> str:
@@ -284,15 +317,24 @@ def rdma_core_for(host: str) -> str:
 
 
 def ssh_args(target: str, command: str) -> list[str]:
-    return [
+    args = [
         "ssh",
+    ]
+    if SSH_CONFIG:
+        args.extend(["-F", SSH_CONFIG])
+    args.extend([
         "-o",
         "ConnectTimeout=8",
         "-o",
         "BatchMode=yes",
+    ])
+    for option in SSH_OPTIONS:
+        args.extend(["-o", option])
+    args.extend([
         target,
         "sudo -n bash -lc " + shlex.quote(command),
-    ]
+    ])
+    return args
 
 
 def run_local(args: list[str], *, check: bool = True, timeout: int | None = None) -> subprocess.CompletedProcess[str]:
@@ -535,6 +577,7 @@ def parse_case_options(case: dict[str, Any]) -> dict[str, str]:
         "--tx-depth": "tx_depth",
         "--rx-depth": "rx_depth",
         "--connection": "connection",
+        "--mtu": "mtu",
     }
     i = 0
     while i < len(argv):
@@ -548,6 +591,25 @@ def parse_case_options(case: dict[str, Any]) -> dict[str, str]:
         i += 1
     out.setdefault("bidirectional", "0")
     return out
+
+
+def cap_option_string(value: str | None, cap: int) -> str:
+    if value is None:
+        return str(cap)
+    try:
+        return str(min(int(value), cap))
+    except ValueError:
+        return value
+
+
+def effective_case_options(case: dict[str, Any], pair_has_apple_rdma: bool) -> dict[str, str]:
+    opts = parse_case_options(case)
+    if pair_has_apple_rdma and case_connection(case) == "UC":
+        opts.setdefault("mtu", str(APPLE_UC_MTU))
+        if perftest_verb(case) == "send":
+            opts["tx_depth"] = cap_option_string(opts.get("tx_depth"), APPLE_UC_QUEUE_DEPTH)
+            opts["rx_depth"] = cap_option_string(opts.get("rx_depth"), APPLE_UC_QUEUE_DEPTH)
+    return opts
 
 
 def strip_option(argv: list[str], flags: set[str]) -> list[str]:
@@ -569,12 +631,56 @@ def strip_option(argv: list[str], flags: set[str]) -> list[str]:
     return out
 
 
+def option_value(argv: list[str], flags: set[str]) -> str | None:
+    i = 0
+    while i < len(argv):
+        item = argv[i]
+        if item in flags and i + 1 < len(argv):
+            return argv[i + 1]
+        for flag in flags:
+            prefix = flag + "="
+            if item.startswith(prefix):
+                return item[len(prefix):]
+        i += 1
+    return None
+
+
+def append_default_option(argv: list[str], flags: set[str], flag: str, value: int) -> None:
+    if option_value(argv, flags) is None:
+        argv.extend([flag, str(value)])
+
+
+def cap_int_option(argv: list[str], flags: set[str], flag: str, value: int) -> list[str]:
+    current = option_value(argv, flags)
+    if current is None:
+        argv.extend([flag, str(value)])
+        return argv
+    try:
+        capped = min(int(current), value)
+    except ValueError:
+        return argv
+    argv = strip_option(argv, flags)
+    argv.extend([flag, str(capped)])
+    return argv
+
+
+def case_connection(case: dict[str, Any]) -> str:
+    argv = [str(x) for x in case.get("argv", [])]
+    return (option_value(argv, {"--connection", "-c"}) or "RC").upper()
+
+
+def is_apple_rdma_dev(dev: str) -> bool:
+    return dev.startswith(APPLE_RDMA_DEV_PREFIX)
+
+
 def build_perftest_command(
     case: dict[str, Any],
     *,
     perftest_path: str,
     rdma_lib: str,
     pair_has_darwin: bool,
+    pair_has_apple_rdma: bool,
+    host_is_darwin: bool,
     dev: str,
     gid_index: int,
     port: int,
@@ -586,6 +692,11 @@ def build_perftest_command(
         [str(x) for x in case.get("argv", [])],
         {"--ib-dev", "-d", "--gid-index", "-x", "--port", "-p", "--out_json_file"},
     )
+    if pair_has_apple_rdma and case_connection(case) == "UC":
+        append_default_option(argv, {"--mtu", "-m"}, "--mtu", APPLE_UC_MTU)
+        if perftest_verb(case) == "send":
+            argv = cap_int_option(argv, {"--tx-depth", "-t"}, "--tx-depth", APPLE_UC_QUEUE_DEPTH)
+            argv = cap_int_option(argv, {"--rx-depth", "-r"}, "--rx-depth", APPLE_UC_QUEUE_DEPTH)
     argv.extend(["--ib-dev", dev, "--gid-index", str(gid_index), "--port", str(port), "-F"])
     if pair_has_darwin and "--use_old_post_send" not in argv:
         # Apple perftest is built with --disable-ibv_wr_api; force both sides
@@ -602,12 +713,13 @@ def build_perftest_command(
     bin_path = f"{perftest_path}/bin/{case['bin']}"
     quoted = " ".join(shlex.quote(str(arg)) for arg in argv)
     lib_prefix = f"LD_LIBRARY_PATH={shlex.quote(rdma_lib + '/lib')} " if rdma_lib else ""
+    timeout_prefix = "" if host_is_darwin else f"timeout {shlex.quote(str(timeout))} "
     return (
         "set -euo pipefail; "
         f"mkdir -p {shlex.quote(str(Path(remote_json).parent))}; "
         f"cd {shlex.quote(str(Path(remote_json).parent))}; "
         f"{lib_prefix}"
-        f"timeout {shlex.quote(str(timeout))} {shlex.quote(bin_path)} {quoted}"
+        f"{timeout_prefix}{shlex.quote(bin_path)} {quoted}"
     )
 
 
@@ -702,6 +814,7 @@ def run_pair(
     client_rdma_lib: str,
     server_dev: str,
     client_dev: str,
+    peer_addr: str,
     gid_index: int,
     port: int,
     timeout: int,
@@ -710,12 +823,17 @@ def run_pair(
     remote_dir = f"/tmp/tbv-perftest/{run_id}"
     server_json = f"{remote_dir}/server.json"
     client_json = f"{remote_dir}/client.json"
-    pair_has_darwin = "Darwin" in (HOST_SYSTEM.get(server), HOST_SYSTEM.get(client))
+    server_is_darwin = HOST_SYSTEM.get(server) == "Darwin"
+    client_is_darwin = HOST_SYSTEM.get(client) == "Darwin"
+    pair_has_darwin = server_is_darwin or client_is_darwin
+    pair_has_apple_rdma = is_apple_rdma_dev(server_dev) or is_apple_rdma_dev(client_dev)
     server_cmd = build_perftest_command(
         case,
         perftest_path=server_perftest,
         rdma_lib=server_rdma_lib,
         pair_has_darwin=pair_has_darwin,
+        pair_has_apple_rdma=pair_has_apple_rdma,
+        host_is_darwin=server_is_darwin,
         dev=server_dev,
         gid_index=gid_index,
         port=port,
@@ -728,12 +846,14 @@ def run_pair(
         perftest_path=client_perftest,
         rdma_lib=client_rdma_lib,
         pair_has_darwin=pair_has_darwin,
+        pair_has_apple_rdma=pair_has_apple_rdma,
+        host_is_darwin=client_is_darwin,
         dev=client_dev,
         gid_index=gid_index,
         port=port,
         timeout=timeout,
         remote_json=client_json,
-        peer=server,
+        peer=peer_addr,
     )
 
     server_proc = subprocess.Popen(
@@ -743,11 +863,33 @@ def run_pair(
         text=True,
     )
     time.sleep(server_start_delay)
-    client_proc = run_ssh(client, client_cmd, check=False, timeout=timeout + 20)
+    try:
+        client_proc = run_ssh(client, client_cmd, check=False, timeout=timeout + 20)
+    except subprocess.TimeoutExpired as exc:
+        cleanup_remote_run(server, remote_dir)
+        cleanup_remote_run(client, remote_dir)
+        server_proc.terminate()
+        try:
+            server_stdout, _ = server_proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            server_proc.kill()
+            server_stdout, _ = server_proc.communicate()
+        stdout = exc.stdout or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        return "fail", {}, f"client ssh timeout: {str(stdout).strip()[-800:]}", {
+            "server_stdout": server_stdout,
+            "client_stdout": stdout,
+            "server_returncode": server_proc.returncode,
+            "client_returncode": None,
+            "server_json": load_remote_json(server, server_json),
+            "client_json": load_remote_json(client, client_json),
+        }
     server_reap_error = ""
     try:
         server_stdout, _ = server_proc.communicate(timeout=15)
     except subprocess.TimeoutExpired:
+        cleanup_remote_run(server, remote_dir)
         server_proc.terminate()
         try:
             server_stdout, _ = server_proc.communicate(timeout=5)
@@ -850,12 +992,31 @@ def parse_hosts(value: str) -> tuple[str, str]:
     return parts[0], parts[1]
 
 
+def parse_host_map(value: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not value:
+        return out
+    for part in re.split(r"[, ]+", value):
+        if not part:
+            continue
+        host, sep, addr = part.partition("=")
+        if not sep or not host or not addr:
+            die("--data-addrs entries must look like host=addr")
+        out[host] = addr
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run a Nix-generated perftest benchmark plan.")
     parser.add_argument("--plan", required=True)
     parser.add_argument("--server")
     parser.add_argument("--client")
     parser.add_argument("--hosts", help="Shortcut for --server A --client B")
+    parser.add_argument("--server-data-addr", help="address clients should use to connect to the server host")
+    parser.add_argument("--client-data-addr", help="address clients should use to connect to the client host when directions reverse")
+    parser.add_argument("--data-addrs", help="comma-separated host=addr map for perftest's data connection target")
+    parser.add_argument("--ssh-config", help="ssh_config file passed to ssh with -F")
+    parser.add_argument("--ssh-option", action="append", default=[], help="extra ssh -o option; may be repeated")
     parser.add_argument("--dev")
     parser.add_argument("--server-dev", help="override --dev on the server side (asymmetric pairs)")
     parser.add_argument("--client-dev", help="override --dev on the client side (asymmetric pairs)")
@@ -885,6 +1046,9 @@ def main() -> int:
     args = parser.parse_args()
     if args.repeat < 1:
         die("--repeat must be >= 1")
+    global SSH_CONFIG, SSH_OPTIONS
+    SSH_CONFIG = args.ssh_config or os.environ.get("TBV_SSH_CONFIG", "")
+    SSH_OPTIONS = list(args.ssh_option or [])
 
     plan = json.loads(Path(args.plan).read_text())
     defaults = dict(plan.get("defaults", {}))
@@ -900,7 +1064,18 @@ def main() -> int:
         server: args.server_dev or dev,
         client: args.client_dev or dev,
     }
-    gid_index = args.gid_index if args.gid_index is not None else int(defaults["gidIndex"])
+    host_data_addr = {
+        server: args.server_data_addr or server,
+        client: args.client_data_addr or client,
+    }
+    host_data_addr.update(parse_host_map(args.data_addrs or ""))
+    pair_has_apple_rdma = is_apple_rdma_dev(host_dev[server]) or is_apple_rdma_dev(host_dev[client])
+    if args.gid_index is not None:
+        gid_index = args.gid_index
+    elif pair_has_apple_rdma:
+        gid_index = APPLE_UC_GID_INDEX
+    else:
+        gid_index = int(defaults["gidIndex"])
     backend = args.backend if args.backend is not None else defaults.get("backend")
     netdev = args.netdev or defaults.get("netdev")
     if args.no_rail_check:
@@ -1002,7 +1177,7 @@ def main() -> int:
                         assert_topology(run_server, before_server, expect_rails, expect_speed)
                         assert_topology(run_client, before_client, expect_rails, expect_speed)
 
-                        opts = parse_case_options(case)
+                        opts = effective_case_options(case, pair_has_apple_rdma)
                         row: dict[str, Any] = {
                             "timestamp_utc": now_utc(),
                             "plan": plan["name"],
@@ -1021,7 +1196,15 @@ def main() -> int:
                             "module_ko_path": identity_server.get("ko_path", ""),
                             "iommu": identity_server.get("iommu", ""),
                             "direction": direction_name,
-                            "dev": dev,
+                            "dev": (
+                                host_dev[run_server]
+                                if host_dev[run_server] == host_dev[run_client]
+                                else f"{host_dev[run_server]}->{host_dev[run_client]}"
+                            ),
+                            "server_dev": host_dev[run_server],
+                            "client_dev": host_dev[run_client],
+                            "server_data_addr": host_data_addr.get(run_server, run_server),
+                            "client_data_addr": host_data_addr.get(run_client, run_client),
                             "gid_index": str(gid_index),
                             "port": str(port),
                             "status": "",
@@ -1043,6 +1226,7 @@ def main() -> int:
                             client_rdma_lib=rdma_core_for(run_client),
                             server_dev=host_dev[run_server],
                             client_dev=host_dev[run_client],
+                            peer_addr=host_data_addr.get(run_server, run_server),
                             gid_index=gid_index,
                             port=port,
                             timeout=timeout,

--- a/userspace/bench/tbv_uc_stress.py
+++ b/userspace/bench/tbv_uc_stress.py
@@ -41,6 +41,7 @@ CSV_FIELDS = [
     "repeat_index",
     "repeat_count",
     "port",
+    "connect_host",
     "status",
     "duration_s",
     "sender_rc",
@@ -103,6 +104,12 @@ def ssh_command(host: str, command: str) -> list[str]:
 
 def shell_join(args: list[str]) -> str:
     return " ".join(shlex.quote(arg) for arg in args)
+
+
+def safe_name(value: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip())
+    value = value.strip("-")
+    return value or "run"
 
 
 def uc_command(
@@ -237,13 +244,21 @@ def run_case(
 ) -> dict[str, str]:
     sender_tool = args.sender_tool or args.tool
     receiver_tool = args.receiver_tool or args.tool
-    connect_host = args.connect_host or receiver
+    if args.connect_host:
+        connect_host = args.connect_host
+    elif receiver == args.server:
+        connect_host = args.server_connect_host or receiver
+    elif receiver == args.client:
+        connect_host = args.client_connect_host or receiver
+    else:
+        connect_host = receiver
+    log_prefix = f"{safe_name(args.tag)}-" if args.tag else ""
     receiver_log = log_dir / (
-        f"{direction}-size{size}-sd{send_depth}-mtu{mtu}-"
+        f"{log_prefix}{direction}-port{port}-size{size}-sd{send_depth}-mtu{mtu}-"
         f"rep{repeat_index}-recv.log"
     )
     sender_log = log_dir / (
-        f"{direction}-size{size}-sd{send_depth}-mtu{mtu}-"
+        f"{log_prefix}{direction}-port{port}-size{size}-sd{send_depth}-mtu{mtu}-"
         f"rep{repeat_index}-send.log"
     )
 
@@ -346,6 +361,7 @@ def run_case(
         "repeat_index": str(repeat_index),
         "repeat_count": str(args.repeats),
         "port": str(port),
+        "connect_host": connect_host,
         "status": "ok" if ok else "fail",
         "duration_s": f"{time.monotonic() - start:.3f}",
         "sender_rc": str(sender_rc),
@@ -384,6 +400,16 @@ def main() -> int:
         help="Name/IP sender passes to --connect; defaults to receiver host.",
     )
     parser.add_argument(
+        "--server-connect-host",
+        default="",
+        help="Name/IP senders use when the server side is receiving.",
+    )
+    parser.add_argument(
+        "--client-connect-host",
+        default="",
+        help="Name/IP senders use when the client side is receiving.",
+    )
+    parser.add_argument(
         "--csv",
         default=f"tbv-uc-stress-{dt.datetime.now().strftime('%Y%m%d-%H%M%S')}.csv",
     )
@@ -405,6 +431,7 @@ def main() -> int:
     parser.add_argument("--stop-on-fail", action="store_true")
     parser.add_argument("--no-check", dest="check", action="store_false")
     parser.add_argument("--no-check-any-order", dest="check_any_order", action="store_false")
+    parser.add_argument("--strict-order", dest="check_any_order", action="store_false")
     parser.set_defaults(check=True, check_any_order=True)
     args = parser.parse_args()
 

--- a/userspace/bench/tbv_vllm_smoke.sh
+++ b/userspace/bench/tbv_vllm_smoke.sh
@@ -1,0 +1,537 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hosts=${TBV_VLLM_HOSTS:-192.168.23.136,192.168.23.192}
+counter_hosts=${TBV_VLLM_COUNTER_HOSTS:-$hosts}
+iface=${TBV_VLLM_IFACE:-eno1}
+transport=${TBV_VLLM_TRANSPORT:-native}
+log_parent=${TBV_VLLM_LOG_PARENT:-/mnt/Home/tmp/tbv-vllm-smoke}
+log_root=${TBV_VLLM_LOG_ROOT:-$log_parent/$(date +%Y%m%d-%H%M%S)}
+ssh_cmd=${TBV_SSH:-ssh}
+ssh_opts=${TBV_SSH_OPTS:-"-o BatchMode=yes -o ControlMaster=no -S none -o ConnectTimeout=10 -o ServerAliveInterval=5 -o ServerAliveCountMax=3"}
+capture_counters_enabled=${TBV_VLLM_COUNTERS:-1}
+counter_summary=${TBV_DEBUGFS_SUMMARY:-/sys/kernel/debug/thunderbolt_ibverbs/summary}
+counter_keys=${TBV_VLLM_COUNTER_KEYS:-"data_wr_retransmit data_wr_retry_exhausted data_wr_timeout data_tx_posted data_tx_completed data_tx_errors data_tx_canceled data_rx_completed data_rx_canceled data_rx_repost_failed data_rx_bad_frame data_rx_bad_header data_rx_bad_header_parse data_rx_bad_header_len data_rx_bad_header_path_credit data_rx_bad_header_opcode data_rx_bad_header_recv_credit data_rx_bad_header_ack data_rx_bad_header_write data_rx_bad_header_read_req data_rx_bad_header_mad data_rx_ack data_rx_ack_matched data_rx_ack_match_retried data_rx_ack_miss data_rx_late_ack data_rx_no_qp"}
+hard_error_keys=${TBV_VLLM_HARD_ERROR_KEYS:-"data_wr_retry_exhausted data_wr_timeout data_tx_errors data_tx_canceled data_rx_canceled data_rx_repost_failed data_rx_bad_frame data_rx_bad_header data_rx_bad_header_parse data_rx_bad_header_len data_rx_bad_header_path_credit data_rx_bad_header_opcode data_rx_bad_header_recv_credit data_rx_bad_header_ack data_rx_bad_header_write data_rx_bad_header_read_req data_rx_bad_header_mad data_rx_no_qp"}
+require_rdma=${TBV_VLLM_REQUIRE_RDMA:-auto}
+
+wrapper=${VLLM_USB4_ENV:-${TBV_VLLM_WRAPPER:-}}
+model=${TBV_VLLM_MODEL:-/mnt/Home/tmp/tbv-vllm-tiny-qwen3}
+hf_source=${TBV_VLLM_HF_SOURCE:-Qwen/Qwen3-4B}
+prepare_tiny_model=${TBV_VLLM_PREPARE_TINY_MODEL:-1}
+
+hca=${TBV_VLLM_HCA:-usb4_rdma5}
+gid_index=${TBV_VLLM_GID_INDEX:-}
+qps_per_connection=${TBV_VLLM_QPS_PER_CONNECTION:-1}
+split_data_on_qps=${TBV_VLLM_SPLIT_DATA_ON_QPS:-0}
+channels_per_peer=${TBV_VLLM_CHANNELS_PER_PEER:-1}
+min_channels=${TBV_VLLM_MIN_CHANNELS:-1}
+max_channels=${TBV_VLLM_MAX_CHANNELS:-1}
+nccl_debug=${TBV_VLLM_NCCL_DEBUG:-WARN}
+rdma_lib_dirs=${TBV_VLLM_RDMA_LIB_DIRS:-/run/current-system/sw/lib}
+
+rccl_install=${RCCL_INSTALL_DIR:-}
+rocshmem_install=${ROCSHMEM_INSTALL_DIR:-}
+chunk_bytes=${TBV_ROCSHMEM_USB4_A2A_CHUNK_BYTES:-${ROCSHMEM_GDA_USB4_A2A_CHUNK_BYTES:-524288}}
+threshold=${RCCL_ROCSHMEM_THRESHOLD:-67108864}
+heap_size=${ROCSHMEM_HEAP_SIZE:-1073741824}
+num_sym_buf=${ROCSHMEM_NUM_SYM_BUF:-4}
+
+input_len=${TBV_VLLM_INPUT_LEN:-8}
+output_len=${TBV_VLLM_OUTPUT_LEN:-4}
+num_prompts=${TBV_VLLM_NUM_PROMPTS:-2}
+max_model_len=${TBV_VLLM_MAX_MODEL_LEN:-512}
+kv_cache_bytes=${TBV_VLLM_KV_CACHE_BYTES:-16777216}
+tp_size=${TBV_VLLM_TP_SIZE:-2}
+distributed_backend=${TBV_VLLM_DISTRIBUTED_BACKEND:-ray}
+run_single_first=${TBV_VLLM_SINGLE_FIRST:-1}
+
+usage() {
+  cat <<EOF
+Usage: tbv_vllm_smoke.sh [options]
+
+Runs a small vLLM throughput smoke on two hosts and checks thunderbolt-ibverbs
+debugfs counter deltas. The default transport is native Linux ibverbs. Use
+--transport gda only with a rebuilt RCCL/rocSHMEM stack.
+
+Options:
+  --hosts H1,H2              Default: $hosts
+  --counter-hosts H1,H2      Default: hosts
+  --iface IFACE              Default: $iface
+  --transport native|gda     Default: $transport
+  --log-root DIR             Default: $log_root
+  --ssh CMD                  Default: $ssh_cmd
+  --ssh-opts OPTS            Default: $ssh_opts
+  --no-counters              Skip thunderbolt-ibverbs debugfs counter deltas
+  --require-rdma 0|1|auto    Fail if TP run moves no RDMA counters. Default: $require_rdma
+  --wrapper DIR              vLLM/PyTorch wrapper prefix
+  --model DIR                Tiny model directory. Default: $model
+  --hf-source MODEL          Cached HF tokenizer/config source. Default: $hf_source
+  --prepare-tiny-model 0|1   Default: $prepare_tiny_model
+  --hca LIST                 NCCL/RCCL IB HCA list. Default: $hca
+  --gid-index N              Optional NCCL/RCCL IB GID index
+  --qps-per-connection N     Default: $qps_per_connection
+  --split-data-on-qps 0|1    Default: $split_data_on_qps
+  --channels-per-peer N      Default: $channels_per_peer
+  --min-channels N           Default: $min_channels
+  --max-channels N           Default: $max_channels
+  --nccl-debug LEVEL         Default: $nccl_debug
+  --rdma-lib-dirs DIRS       Colon-separated libibverbs/librdmacm dirs. Default: $rdma_lib_dirs
+  --rccl-install DIR         Required only for --transport gda
+  --rocshmem-install DIR     Required only for --transport gda
+  --chunk-bytes N            GDA chunk bytes. Default: $chunk_bytes
+  --threshold N              GDA RCCL/rocSHMEM threshold. Default: $threshold
+  --num-prompts N            Default: $num_prompts
+  --input-len N              Default: $input_len
+  --output-len N             Default: $output_len
+  --max-model-len N          Default: $max_model_len
+  --kv-cache-bytes N         Default: $kv_cache_bytes
+  --tp-size N                Default: $tp_size
+  --distributed-backend NAME Default: $distributed_backend
+  --single-first 0|1         Run a single-node smoke before TP. Default: $run_single_first
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --hosts) hosts=$2; shift 2 ;;
+    --counter-hosts) counter_hosts=$2; shift 2 ;;
+    --iface) iface=$2; shift 2 ;;
+    --transport) transport=$2; shift 2 ;;
+    --log-root) log_root=$2; shift 2 ;;
+    --ssh) ssh_cmd=$2; shift 2 ;;
+    --ssh-opts) ssh_opts=$2; shift 2 ;;
+    --no-counters) capture_counters_enabled=0; shift ;;
+    --require-rdma) require_rdma=$2; shift 2 ;;
+    --wrapper) wrapper=$2; shift 2 ;;
+    --model) model=$2; shift 2 ;;
+    --hf-source) hf_source=$2; shift 2 ;;
+    --prepare-tiny-model) prepare_tiny_model=$2; shift 2 ;;
+    --hca) hca=$2; shift 2 ;;
+    --gid-index) gid_index=$2; shift 2 ;;
+    --qps-per-connection) qps_per_connection=$2; shift 2 ;;
+    --split-data-on-qps) split_data_on_qps=$2; shift 2 ;;
+    --channels-per-peer) channels_per_peer=$2; shift 2 ;;
+    --min-channels) min_channels=$2; shift 2 ;;
+    --max-channels) max_channels=$2; shift 2 ;;
+    --nccl-debug) nccl_debug=$2; shift 2 ;;
+    --rdma-lib-dirs) rdma_lib_dirs=$2; shift 2 ;;
+    --rccl-install) rccl_install=$2; shift 2 ;;
+    --rocshmem-install) rocshmem_install=$2; shift 2 ;;
+    --chunk-bytes) chunk_bytes=$2; shift 2 ;;
+    --threshold) threshold=$2; shift 2 ;;
+    --num-prompts) num_prompts=$2; shift 2 ;;
+    --input-len) input_len=$2; shift 2 ;;
+    --output-len) output_len=$2; shift 2 ;;
+    --max-model-len) max_model_len=$2; shift 2 ;;
+    --kv-cache-bytes) kv_cache_bytes=$2; shift 2 ;;
+    --tp-size) tp_size=$2; shift 2 ;;
+    --distributed-backend) distributed_backend=$2; shift 2 ;;
+    --single-first) run_single_first=$2; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$transport" in
+  native|gda) ;;
+  *) echo "unsupported transport: $transport" >&2; exit 2 ;;
+esac
+case "$require_rdma" in
+  0|1|auto) ;;
+  *) echo "unsupported --require-rdma value: $require_rdma" >&2; exit 2 ;;
+esac
+
+IFS=, read -r -a host_list <<< "$hosts"
+if ((${#host_list[@]} != 2)); then
+  echo "expected exactly two hosts, got: $hosts" >&2
+  exit 2
+fi
+head_host=${host_list[0]}
+worker_host=${host_list[1]}
+read -r -a ssh_opts_array <<< "$ssh_opts"
+
+run_remote() {
+  local host=$1
+  shift
+
+  "$ssh_cmd" "${ssh_opts_array[@]}" "$host" "$@"
+}
+
+host_list_from_csv() {
+  local raw=${1//,/ }
+  local host
+
+  for host in $raw; do
+    [[ -n "$host" ]] && printf '%s\n' "$host"
+  done
+}
+
+safe_name() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '_'
+}
+
+counter_file() {
+  printf '%s/counters/%s.%s.summary' "$log_root" "$(safe_name "$1")" "$(safe_name "$2")"
+}
+
+capture_counters() {
+  local label=$1
+  local quoted_summary
+  local host
+  local out
+  local err
+  local cmd
+
+  [[ "$capture_counters_enabled" == 1 ]] || return 0
+  mkdir -p "$log_root/counters"
+  printf -v quoted_summary '%q' "$counter_summary"
+  cmd="if command -v sudo >/dev/null 2>&1; then sudo -n cat $quoted_summary 2>/dev/null || cat $quoted_summary; else cat $quoted_summary; fi"
+
+  for host in $(host_list_from_csv "$counter_hosts"); do
+    out=$(counter_file "$label" "$host")
+    err="$out.err"
+    if run_remote "$host" "$cmd" >"$out.tmp" 2>"$err"; then
+      mv "$out.tmp" "$out"
+      rm -f "$err"
+    else
+      mv "$out.tmp" "$out" 2>/dev/null || :
+      echo "WARN: could not capture counters from $host; see $err" >&2
+    fi
+  done
+}
+
+counter_value() {
+  local file=$1
+  local key=$2
+
+  awk -F':[[:space:]]*' -v key="$key" '
+    $1 == key {
+      value = $2
+      sub(/[[:space:]].*/, "", value)
+      print value ~ /^-?[0-9]+$/ ? value : 0
+      found = 1
+      exit
+    }
+    END { if (!found) print 0 }
+  ' "$file" 2>/dev/null || printf '0\n'
+}
+
+counter_delta_one() {
+  local before_label=$1
+  local after_label=$2
+  local host=$3
+  local key=$4
+  local before_value
+  local after_value
+
+  before_value=$(counter_value "$(counter_file "$before_label" "$host")" "$key")
+  after_value=$(counter_value "$(counter_file "$after_label" "$host")" "$key")
+  printf '%d\n' "$((after_value - before_value))"
+}
+
+counter_delta_sum() {
+  local before_label=$1
+  local after_label=$2
+  local key=$3
+  local host
+  local total=0
+
+  for host in $(host_list_from_csv "$counter_hosts"); do
+    total=$((total + $(counter_delta_one "$before_label" "$after_label" "$host" "$key")))
+  done
+  printf '%d\n' "$total"
+}
+
+print_counter_deltas() {
+  local before_label=$1
+  local after_label=$2
+  local key
+  local host
+  local delta
+  local total
+
+  [[ "$capture_counters_enabled" == 1 ]] || return 0
+  {
+    printf 'TBV counter deltas (%s -> %s):\n' "$before_label" "$after_label"
+    for key in $counter_keys; do
+      total=0
+      for host in $(host_list_from_csv "$counter_hosts"); do
+        delta=$(counter_delta_one "$before_label" "$after_label" "$host" "$key")
+        total=$((total + delta))
+        printf '  %-34s %-16s %+d\n' "$key" "$host" "$delta"
+      done
+      printf '  %-34s %-16s %+d\n' "$key" "sum" "$total"
+    done
+  } | tee "$log_root/counters/deltas.log"
+}
+
+assert_clean_counters() {
+  local before_label=$1
+  local after_label=$2
+  local key
+  local delta
+  local failed=0
+
+  [[ "$capture_counters_enabled" == 1 ]] || return 0
+  for key in $hard_error_keys; do
+    delta=$(counter_delta_sum "$before_label" "$after_label" "$key")
+    if ((delta != 0)); then
+      echo "ERROR: expected $key delta == 0, got $delta" | tee -a "$log_root/counters/deltas.log" >&2
+      failed=1
+    fi
+  done
+  return "$failed"
+}
+
+assert_rdma_used() {
+  local before_label=$1
+  local after_label=$2
+  local tx_delta
+  local rx_delta
+
+  [[ "$capture_counters_enabled" == 1 ]] || return 0
+  [[ "$require_rdma" == 1 ]] || {
+    [[ "$require_rdma" == auto && "$tp_size" -gt 1 ]] || return 0
+  }
+
+  tx_delta=$(counter_delta_sum "$before_label" "$after_label" data_tx_posted)
+  rx_delta=$(counter_delta_sum "$before_label" "$after_label" data_rx_completed)
+  if ((tx_delta == 0 && rx_delta == 0)); then
+    echo "ERROR: TP run completed but thunderbolt-ibverbs data counters did not move" | tee -a "$log_root/counters/deltas.log" >&2
+    echo "ERROR: data_tx_posted delta=$tx_delta data_rx_completed delta=$rx_delta" | tee -a "$log_root/counters/deltas.log" >&2
+    return 1
+  fi
+}
+
+require_dir() {
+  local name=$1
+  local path=$2
+  if [[ -z "$path" || ! -d "$path" ]]; then
+    echo "$name is required and must be a directory: ${path:-<unset>}" >&2
+    exit 2
+  fi
+}
+
+resolve_wrapped_bin() {
+  local path=$1
+  local target
+
+  target=$(sed -n 's/^exec "\([^"]*\)".*/\1/p' "$path" | head -n 1 || true)
+  if [[ -n "$target" && -x "$target" ]]; then
+    printf '%s\n' "$target"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
+require_dir "wrapper" "$wrapper"
+if [[ "$transport" == gda ]]; then
+  require_dir "rccl install" "$rccl_install"
+  require_dir "rocshmem install" "$rocshmem_install"
+fi
+
+python_wrapper=$wrapper/bin/python3
+vllm_wrapper=$wrapper/bin/vllm
+ray_wrapper=$wrapper/bin/ray
+if [[ ! -x "$python_wrapper" || ! -x "$vllm_wrapper" || ! -x "$ray_wrapper" ]]; then
+  echo "wrapper must provide bin/python3, bin/vllm, and bin/ray: $wrapper" >&2
+  exit 2
+fi
+
+python=$(resolve_wrapped_bin "$python_wrapper")
+vllm=$(resolve_wrapped_bin "$vllm_wrapper")
+ray=$(resolve_wrapped_bin "$ray_wrapper")
+if [[ ! -x "$python" || ! -x "$vllm" || ! -x "$ray" ]]; then
+  echo "resolved wrapper commands must be executable: python=$python vllm=$vllm ray=$ray" >&2
+  exit 2
+fi
+
+mkdir -p "$log_root"
+{
+  echo "transport=$transport"
+  echo "wrapper=$wrapper"
+  echo "python=$python"
+  echo "vllm=$vllm"
+  echo "ray=$ray"
+  echo "rccl_install=$rccl_install"
+  echo "rocshmem_install=$rocshmem_install"
+  echo "model=$model"
+  echo "hosts=$hosts"
+  echo "counter_hosts=$counter_hosts"
+  echo "iface=$iface"
+  echo "hca=$hca"
+  echo "gid_index=$gid_index"
+  echo "qps_per_connection=$qps_per_connection"
+  echo "split_data_on_qps=$split_data_on_qps"
+  echo "channels_per_peer=$channels_per_peer"
+  echo "rdma_lib_dirs=$rdma_lib_dirs"
+  echo "capture_counters=$capture_counters_enabled"
+} > "$log_root/config.txt"
+
+if [[ "$prepare_tiny_model" == 1 ]]; then
+  "$python" - "$hf_source" "$model" > "$log_root/prepare-model.log" <<'PY'
+from pathlib import Path
+import sys
+
+from transformers import AutoConfig, AutoTokenizer, Qwen3Config
+
+src = sys.argv[1]
+out = Path(sys.argv[2])
+out.mkdir(parents=True, exist_ok=True)
+
+tok = AutoTokenizer.from_pretrained(src, local_files_only=True)
+tok.save_pretrained(out)
+base = AutoConfig.from_pretrained(src, local_files_only=True)
+config = Qwen3Config(
+    vocab_size=len(tok),
+    hidden_size=128,
+    intermediate_size=384,
+    num_hidden_layers=2,
+    num_attention_heads=2,
+    num_key_value_heads=2,
+    head_dim=64,
+    hidden_act=getattr(base, "hidden_act", "silu"),
+    max_position_embeddings=512,
+    initializer_range=getattr(base, "initializer_range", 0.02),
+    rms_norm_eps=getattr(base, "rms_norm_eps", 1e-6),
+    use_cache=True,
+    tie_word_embeddings=False,
+    rope_theta=getattr(base, "rope_theta", 1000000.0),
+    bos_token_id=tok.bos_token_id,
+    eos_token_id=tok.eos_token_id,
+    pad_token_id=tok.pad_token_id if tok.pad_token_id is not None else tok.eos_token_id,
+)
+config.architectures = ["Qwen3ForCausalLM"]
+config.dtype = "float16"
+config.save_pretrained(out)
+print(f"model={out}")
+print(f"vocab_size={config.vocab_size} pad_token_id={config.pad_token_id}")
+PY
+fi
+
+for host in "${host_list[@]}"; do
+  run_remote "$host" \
+    "test -x $(printf '%q' "$vllm_wrapper") && test -x $(printf '%q' "$ray_wrapper") && test -d $(printf '%q' "$model")"
+done
+
+base_remote_env() {
+  printf 'export GLOO_SOCKET_IFNAME=%q NCCL_SOCKET_IFNAME=%q RCCL_SOCKET_IFNAME=%q; ' \
+    "$iface" "$iface" "$iface"
+  printf 'export NCCL_IB_DISABLE=0 RCCL_IB_DISABLE=0; '
+  if [[ -n "$hca" ]]; then
+    printf 'export NCCL_IB_HCA=%q RCCL_IB_HCA=%q; ' "$hca" "$hca"
+  fi
+  if [[ -n "$gid_index" ]]; then
+    printf 'export NCCL_IB_GID_INDEX=%q RCCL_IB_GID_INDEX=%q; ' "$gid_index" "$gid_index"
+  fi
+  printf 'export NCCL_IB_QPS_PER_CONNECTION=%q RCCL_IB_QPS_PER_CONNECTION=%q; ' \
+    "$qps_per_connection" "$qps_per_connection"
+  printf 'export NCCL_IB_SPLIT_DATA_ON_QPS=%q RCCL_IB_SPLIT_DATA_ON_QPS=%q; ' \
+    "$split_data_on_qps" "$split_data_on_qps"
+  printf 'export NCCL_NCHANNELS_PER_NET_PEER=%q RCCL_NCHANNELS_PER_NET_PEER=%q; ' \
+    "$channels_per_peer" "$channels_per_peer"
+  printf 'export NCCL_MIN_NCHANNELS=%q RCCL_MIN_NCHANNELS=%q NCCL_MAX_NCHANNELS=%q RCCL_MAX_NCHANNELS=%q; ' \
+    "$min_channels" "$min_channels" "$max_channels" "$max_channels"
+  printf 'export VLLM_NO_USAGE_STATS=1 VLLM_DO_NOT_TRACK=1 RAY_USAGE_STATS_ENABLED=0 RAY_DEDUP_LOGS=0 NCCL_DEBUG=%q RCCL_DEBUG=%q; ' \
+    "$nccl_debug" "$nccl_debug"
+  if [[ -n "$rdma_lib_dirs" ]]; then
+    # RCCL dlopens libibverbs/librdmacm by soname; Nix wrappers do not expose
+    # system RDMA libraries to Ray workers unless we pass the library path here.
+    # shellcheck disable=SC2016
+    printf 'export LD_LIBRARY_PATH=%q:${LD_LIBRARY_PATH:-}; ' "$rdma_lib_dirs"
+  fi
+}
+
+gda_remote_env() {
+  # Expand LD_LIBRARY_PATH on the remote host, not while building this command.
+  # shellcheck disable=SC2016
+  printf 'export LD_LIBRARY_PATH=%q:%q:${LD_LIBRARY_PATH:-}; ' \
+    "$rccl_install/lib" "$rocshmem_install/lib"
+  printf 'export RCCL_ROCSHMEM_ENABLE=1 RCCL_ROCSHMEM_FORCE_ENABLE=1 RCCL_ROCSHMEM_THRESHOLD=%q RCCL_ROCSHMEM_HOST_STREAM_TIMING=1; ' \
+    "$threshold"
+  printf 'export ROCSHMEM_GDA_PROVIDER=ib ROCSHMEM_GDA_ENABLE_DMABUF=1 ROCSHMEM_GDA_USB4_A2A_CHUNK_BYTES=%q ROCSHMEM_GDA_USB4_ALLTOALL_MODE=0 ROCSHMEM_GDA_USB4_ALLTOALL_ACK=0; ' \
+    "$chunk_bytes"
+  printf 'export ROCSHMEM_GDA_QP_TIMEOUT=14 ROCSHMEM_GDA_QP_RETRY_CNT=7 ROCSHMEM_GDA_QP_RNR_RETRY=7 ROCSHMEM_NUM_SYM_BUF=%q ROCSHMEM_HEAP_SIZE=%q; ' \
+    "$num_sym_buf" "$heap_size"
+}
+
+remote_env() {
+  base_remote_env
+  if [[ "$transport" == gda ]]; then
+    gda_remote_env
+  fi
+}
+
+stop_ray() {
+  local host=$1
+  local log=$2
+
+  run_remote "$host" \
+    "$(remote_env) $(printf '%q' "$ray") stop --force 2>&1 | tail -200" > "$log" 2>&1 || true
+}
+
+cleanup() {
+  stop_ray "$worker_host" "$log_root/ray-stop-worker.log"
+  stop_ray "$head_host" "$log_root/ray-stop-head.log"
+}
+
+finish() {
+  local status=$?
+
+  set +e
+  capture_counters after
+  print_counter_deltas before after
+  if ((status == 0)); then
+    assert_clean_counters before after || status=1
+    assert_rdma_used before after || status=1
+  fi
+  cleanup
+  exit "$status"
+}
+trap finish EXIT
+
+stop_ray "$worker_host" "$log_root/ray-stop-worker-before.log"
+stop_ray "$head_host" "$log_root/ray-stop-head-before.log"
+
+capture_counters before
+
+run_vllm_cmd() {
+  local out=$1
+  local distributed_args=$2
+
+  printf 'mkdir -p %q; ' "$out"
+  printf '%s ' "$(remote_env)"
+  printf '%q bench throughput ' "$vllm"
+  printf -- '--backend vllm --dataset-name random '
+  printf -- '--random-input-len %q --random-output-len %q --num-prompts %q ' \
+    "$input_len" "$output_len" "$num_prompts"
+  printf -- '--model %q --runner generate --load-format dummy --dtype float16 ' "$model"
+  printf -- '--max-model-len %q --kv-cache-memory-bytes %q ' "$max_model_len" "$kv_cache_bytes"
+  printf -- '--enforce-eager --disable-custom-all-reduce --disable-detokenize '
+  printf '%s ' "$distributed_args"
+  printf -- '--output-json %q > %q 2>&1; cat %q' \
+    "$out/results.json" "$out/run.log" "$out/results.json"
+}
+
+if [[ "$run_single_first" == 1 ]]; then
+  single_root=$log_root/single
+  run_remote "$head_host" "$(run_vllm_cmd "$single_root" "")" \
+    | tee "$single_root.results.json"
+fi
+
+run_remote "$head_host" \
+  "$(remote_env) $(printf '%q' "$ray") start --head --node-ip-address=$(printf '%q' "$head_host") --port=6379 --num-gpus=1 --disable-usage-stats" \
+  > "$log_root/ray-head-start.log" 2>&1
+run_remote "$worker_host" \
+  "$(remote_env) $(printf '%q' "$ray") start --address=$(printf '%q' "$head_host:6379") --node-ip-address=$(printf '%q' "$worker_host") --num-gpus=1 --disable-usage-stats" \
+  > "$log_root/ray-worker-start.log" 2>&1
+run_remote "$head_host" \
+  "$(remote_env) $(printf '%q' "$ray") status" > "$log_root/ray-status-before.log" 2>&1
+
+tp_root=$log_root/tp$tp_size
+run_remote "$head_host" \
+  "$(run_vllm_cmd "$tp_root" "--distributed-executor-backend $distributed_backend --tensor-parallel-size $tp_size")" \
+  | tee "$tp_root.results.json"
+
+echo "vLLM smoke complete: log_root=$log_root"

--- a/userspace/bench/uc_oneway.c
+++ b/userspace/bench/uc_oneway.c
@@ -61,6 +61,8 @@ struct opts {
 	int check_any_order;
 	int recv_wr_id_base;
 	int send_wr_id_base;
+	int hold_after_rts_ms;
+	int hold_before_destroy_ms;
 	size_t size;
 };
 
@@ -168,6 +170,7 @@ static void usage(const char *argv0)
 		"          [--mtu 256|512|1024|2048|4096]\n"
 		"          [--recv-post-delay-ms N]\n"
 		"          [--recv-wr-id-base N] [--send-wr-id-base N]\n"
+		"          [--hold-after-rts-ms N] [--hold-before-destroy-ms N]\n"
 		"          [--check] [--check-any-order]\n",
 		argv0);
 }
@@ -285,6 +288,12 @@ static int parse_opts(int argc, char **argv, struct opts *o)
 		} else if (!strcmp(argv[i], "--send-wr-id-base") && i + 1 < argc) {
 			if (parse_int(argv[++i], &o->send_wr_id_base))
 				return -1;
+		} else if (!strcmp(argv[i], "--hold-after-rts-ms") && i + 1 < argc) {
+			if (parse_int(argv[++i], &o->hold_after_rts_ms))
+				return -1;
+		} else if (!strcmp(argv[i], "--hold-before-destroy-ms") && i + 1 < argc) {
+			if (parse_int(argv[++i], &o->hold_before_destroy_ms))
+				return -1;
 		} else if (!strcmp(argv[i], "--count") && i + 1 < argc) {
 			if (parse_int(argv[++i], &o->count))
 				return -1;
@@ -307,7 +316,8 @@ static int parse_opts(int argc, char **argv, struct opts *o)
 	if (!o->role || !o->dev || o->port <= 0 || o->port > 65535 ||
 	    o->gid_index < -1 || o->ib_port <= 0 || o->depth <= 0 ||
 	    o->depth > 4095 || o->send_slots < 0 || o->recv_posts < 0 ||
-	    o->recv_posts > 4095 || o->count <= 0)
+	    o->recv_posts > 4095 || o->count <= 0 ||
+	    o->hold_after_rts_ms < 0 || o->hold_before_destroy_ms < 0)
 		return -1;
 	if (o->mtu != 256 && o->mtu != 512 && o->mtu != 1024 &&
 	    o->mtu != 2048 && o->mtu != 4096)
@@ -904,6 +914,12 @@ int main(int argc, char **argv)
 		goto out_qp;
 	fprintf(stderr, "QP is RTS\n");
 	fflush(stderr);
+	if (o.hold_after_rts_ms > 0) {
+		fprintf(stderr, "holding after RTS for %d ms\n",
+			o.hold_after_rts_ms);
+		fflush(stderr);
+		usleep((useconds_t)o.hold_after_rts_ms * 1000u);
+	}
 
 	if (!is_sender || is_bidi) {
 		if (o.recv_post_delay_ms > 0) {
@@ -1203,6 +1219,12 @@ int main(int argc, char **argv)
 	}
 
 	print_rate(o.role, o.count, o.count, o.size, start, &last_t, &last_done);
+	if (o.hold_before_destroy_ms > 0) {
+		fprintf(stderr, "holding before destroy for %d ms\n",
+			o.hold_before_destroy_ms);
+		fflush(stderr);
+		usleep((useconds_t)o.hold_before_destroy_ms * 1000u);
+	}
 	ret = 0;
 
 out_qp:


### PR DESCRIPTION
This consolidates the correctness-related stack that was previously split across #26, #27, #28, #29, and the original #30 branch.

Folded in:
- XDomain foundation kernel patch stack from #26.
- Apple RDMA perftest workflow support from #27.
- Apple TBnet-gated FA57 tunnel lifecycle work from #28/#30.
- Native Linux correctness diagnostics, smoke tooling, and benchmark helpers from #29.

Important cleanup from integration testing:
- Kept minimal ThunderboltIP E2E flow control behind the local `tbnet_identity_minimal_e2e` gate, default off. The ungated peer-advertised E2E behavior caused macOS `modify RTR` failures during goblin<->strix testing.
- Left scratch/review Markdown out of the commit.

Validation run:
- `nix build .#thunderbolt-ibverbs-linux-thunderbolt --builders '' --print-out-paths`
- `nix build .#bench-tools --builders '' --print-out-paths`
- `python3 -m py_compile userspace/bench/tbv_perftest_runner.py userspace/bench/tbv_uc_stress.py`
- `bash -n userspace/bench/tbv_vllm_smoke.sh tools/tbv-target-module.sh`
- Live-loaded the consolidated module on `strix-2` against the 7.1.0-rc1 Thunderbolt kernel patches.
- Smoke tested goblin <-> strix-2 Apple RDMA:
  - Mac -> Linux: 4 x 64 KiB checked UC SENDs passed.
  - Linux -> Mac: 4 x 4 KiB checked UC SENDs passed.
  - Apple RX correctness counters stayed zero: no resync drops, rail mismatches, CQ overflows, or length overruns.

This PR is intentionally one squashed commit on top of `main` so review/merge has a single correctness story.