### PR TITLE
correctness: add post-merge guards and repair patch checks

### DIFF
--- a/kernel-workflow/patches/0122-thunderbolt-xdomain-property-fixes.patch
+++ b/kernel-workflow/patches/0122-thunderbolt-xdomain-property-fixes.patch
@@ -1,7 +1,7 @@
 From e0abb380927d767d76163c942deee323935e883c Mon Sep 17 00:00:00 2001
 From: georgewhewell <georgerw@gmail.com>
 Date: Sat, 6 Jun 2026 15:30:17 +0200
-Subject: [PATCH] thunderbolt: backport XDomain property hardening fixes
+Subject: [PATCH] thunderbolt: backport property parser hardening fixes
 
 Backport the accepted Westeri fixes onto the thunderbolt-ibverbs portable patch base after the USB4STREAM/property-merge local stack:
 
@@ -15,17 +15,10 @@ Backport the accepted Westeri fixes onto the thunderbolt-ibverbs portable patch 
 
   65423079c742 thunderbolt: Bound root directory content to block size
 
-  322e93448d90 thunderbolt: Clamp XDomain response data copy to allocation size
-
-  a504b9f2797b thunderbolt: Validate XDomain request packet size before type cast
-
-  4db2bd2ed478 thunderbolt: Limit XDomain response copy to actual frame size
-
-These fixes are carried as one rebased patch because the raw maintainer-tree mbox conflicts with the local property merge and USB4STREAM patch stack.
+The XDomain response-copy and request-size hardening fixes are carried by the identity-match patch earlier in the local stack, where they are needed for macOS property-response interop.
 ---
  drivers/thunderbolt/property.c | 38 ++++++++++++++++++++++++++--------
- drivers/thunderbolt/xdomain.c  | 14 ++++++++++---
- 2 files changed, 40 insertions(+), 12 deletions(-)
+ 1 file changed, 30 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/thunderbolt/property.c b/drivers/thunderbolt/property.c
 index 6b9666b61..df18a6d69 100644
@@ -151,73 +144,5 @@ index 6b9666b61..df18a6d69 100644
  }
  
  /**
-diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
-index d45f03207..395c7cd12 100644
---- a/drivers/thunderbolt/xdomain.c
-+++ b/drivers/thunderbolt/xdomain.c
-@@ -55,6 +55,7 @@ static const char * const state_names[] = {
- struct xdomain_request_work {
- 	struct work_struct work;
- 	struct tb_xdp_header *pkg;
-+	size_t pkg_len;
- 	struct tb *tb;
- };
- 
-@@ -122,7 +123,9 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
- static bool tb_xdomain_copy(struct tb_cfg_request *req,
- 			    const struct ctl_pkg *pkg)
- {
--	memcpy(req->response, pkg->buffer, req->response_size);
-+	size_t len = min_t(size_t, pkg->frame.size, req->response_size);
-+
-+	memcpy(req->response, pkg->buffer, len);
- 	req->result.err = 0;
- 	return true;
- }
-@@ -398,6 +401,8 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
- 			}
- 		}
- 
-+		if (req.offset + len > data_len)
-+			len = data_len - req.offset;
- 		memcpy(data + req.offset, res->data, len * 4);
- 		req.offset += len;
- 	} while (!data_len || req.offset < data_len);
-@@ -755,6 +760,7 @@ static void tb_xdp_handle_request(struct work_struct *work)
- 	struct xdomain_request_work *xw = container_of(work, typeof(*xw), work);
- 	const struct tb_xdp_header *pkg = xw->pkg;
- 	const struct tb_xdomain_header *xhdr = &pkg->xd_hdr;
-+	size_t pkg_len = xw->pkg_len;
- 	struct tb *tb = xw->tb;
- 	struct tb_ctl *ctl = tb->ctl;
- 	struct tb_xdomain *xd;
-@@ -786,7 +792,7 @@ static void tb_xdp_handle_request(struct work_struct *work)
- 	switch (pkg->type) {
- 	case PROPERTIES_REQUEST:
- 		tb_dbg(tb, "%llx: received XDomain properties request\n", route);
--		if (xd) {
-+		if (xd && pkg_len >= sizeof(struct tb_xdp_properties)) {
- 			ret = tb_xdp_properties_response(tb, ctl, xd, sequence,
- 				(const struct tb_xdp_properties *)pkg);
- 		}
-@@ -879,7 +885,8 @@ static void tb_xdp_handle_request(struct work_struct *work)
- 		tb_dbg(tb, "%llx: received XDomain link state change request\n",
- 		       route);
- 
--		if (xd && xd->state == XDOMAIN_STATE_BONDING_UUID_HIGH) {
-+		if (xd && xd->state == XDOMAIN_STATE_BONDING_UUID_HIGH &&
-+		    pkg_len >= sizeof(struct tb_xdp_link_state_change)) {
- 			const struct tb_xdp_link_state_change *lsc =
- 				(const struct tb_xdp_link_state_change *)pkg;
- 
-@@ -932,6 +939,7 @@ tb_xdp_schedule_request(struct tb *tb, const struct tb_xdp_header *hdr,
- 		kfree(xw);
- 		return false;
- 	}
-+	xw->pkg_len = size;
- 	xw->tb = tb_domain_get(tb);
- 
- 	schedule_work(&xw->work);
 -- 
 2.54.0
-

--- a/kernel-workflow/patches/local-portable.nix
+++ b/kernel-workflow/patches/local-portable.nix
@@ -15,8 +15,4 @@ builtins.filter (patch: !(builtins.elem patch.name debugNames)) (import ./local.
     name = "usb4-xdomain-lane-bonding-module-param";
     patch = ./0009-thunderbolt-xdomain-lane-bonding-module-param.patch;
   }
-  {
-    name = "usb4-xdomain-route-trace";
-    patch = ./0010-thunderbolt-trace-XDomain-route-matching.patch;
-  }
 ]

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -38,6 +38,7 @@ help:
 	@echo "  tbnet_identity=auto|stock|stock_proxy|minimal_packet|off"
 	@echo "  tbnet_identity_tbnet=<netdev>"
 	@echo "  tbnet_identity_gid=auto|<netdev>"
+	@echo "  tbnet_identity_minimal_e2e=0|1"
 	@echo "  tbnet_identity_minimal_apple_only=0|1"
 	@echo "  bind_services=0|1"
 	@echo "  allocate_rings=0|1"

--- a/kernel/tbnet_minimal.c
+++ b/kernel/tbnet_minimal.c
@@ -33,6 +33,7 @@
 #include <net/net_namespace.h>
 
 #include "tbv.h"
+#include "proto/tbnet.h"
 
 #define TBV_TBNET_MIN_LOGIN_DELAY_MS	4500
 #define TBV_TBNET_MIN_LOGIN_TIMEOUT_MS	500
@@ -40,9 +41,6 @@
 #define TBV_TBNET_MIN_LOGOUT_TIMEOUT_MS	1000
 #define TBV_TBNET_MIN_RING_SIZE		256
 #define TBV_TBNET_MIN_FRAME_SIZE	SZ_4K
-#define TBV_TBNET_E2E			BIT(0)
-#define TBV_TBNET_MATCH_FRAGS_ID	BIT(1)
-#define TBV_TBNET_64K_FRAMES		BIT(2)
 #define TBV_TBNET_L0_PORT_NUM(route)	((route) & GENMASK(5, 0))
 #define TBV_TBNET_PDF_FRAME_START	1
 #define TBV_TBNET_PDF_FRAME_END		2
@@ -387,8 +385,8 @@ tbv_tbnet_minimal_alloc_rings(struct tbv_tbnet_minimal_session *session)
 	int hopid;
 	int ret;
 
-	if (session->identity->minimal_e2e &&
-	    session->svc->prtcstns & TBV_TBNET_E2E)
+	if (tbv_tbnet_minimal_e2e_enabled(session->identity->minimal_e2e,
+					  session->svc->prtcstns))
 		flags |= RING_FLAG_E2E;
 
 	session->tx_ring = tb_ring_alloc_tx(session->xd->tb->nhi, -1,
@@ -1536,7 +1534,7 @@ static struct tb_service_driver tbv_tbnet_minimal_driver = {
 
 int tbv_tbnet_minimal_start(struct tbv_tbnet_identity *identity)
 {
-	u32 prtcstns = TBV_TBNET_MATCH_FRAGS_ID | TBV_TBNET_64K_FRAMES;
+	u32 prtcstns = tbv_tbnet_minimal_prtcstns(identity->minimal_e2e);
 	int ret;
 
 #ifndef TB_PROTOCOL_HANDLER_UNREGISTER_DRAINS
@@ -1556,8 +1554,6 @@ int tbv_tbnet_minimal_start(struct tbv_tbnet_identity *identity)
 					       "prtcvers", 1);
 	ret = ret ?: tb_property_add_immediate(identity->minimal_dir,
 					       "prtcrevs", 1);
-	if (identity->minimal_e2e)
-		prtcstns |= TBV_TBNET_E2E;
 	ret = ret ?: tb_property_add_immediate(identity->minimal_dir,
 					       "prtcstns",
 					       prtcstns);

--- a/proto/tbnet.h
+++ b/proto/tbnet.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause */
+#ifndef TBV_TBNET_H
+#define TBV_TBNET_H
+
+#ifdef __KERNEL__
+#include <linux/types.h>
+typedef u32 tbv_tbnet_u32;
+#else
+#include <stdbool.h>
+#include <stdint.h>
+typedef uint32_t tbv_tbnet_u32;
+#endif
+
+enum tbv_tbnet_prtcstns {
+	TBV_TBNET_PRTCSTNS_E2E = 1u << 0,
+	TBV_TBNET_PRTCSTNS_MATCH_FRAGS_ID = 1u << 1,
+	TBV_TBNET_PRTCSTNS_64K_FRAMES = 1u << 2,
+};
+
+#define TBV_TBNET_MINIMAL_BASE_PRTCSTNS \
+	(TBV_TBNET_PRTCSTNS_MATCH_FRAGS_ID | TBV_TBNET_PRTCSTNS_64K_FRAMES)
+
+static inline tbv_tbnet_u32 tbv_tbnet_minimal_prtcstns(bool local_e2e)
+{
+	tbv_tbnet_u32 prtcstns = TBV_TBNET_MINIMAL_BASE_PRTCSTNS;
+
+	if (local_e2e)
+		prtcstns |= TBV_TBNET_PRTCSTNS_E2E;
+
+	return prtcstns;
+}
+
+static inline bool tbv_tbnet_minimal_e2e_enabled(bool local_e2e,
+						 tbv_tbnet_u32 peer_prtcstns)
+{
+	return local_e2e &&
+	       (peer_prtcstns & TBV_TBNET_PRTCSTNS_E2E) != 0;
+}
+
+#endif /* TBV_TBNET_H */

--- a/tools/ci/proto-smoke.c
+++ b/tools/ci/proto-smoke.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "proto/native_data.h"
+#include "proto/tbnet.h"
 
 static int hello_equal(const struct tbv_native_wire_hello *a,
 		       const struct tbv_native_wire_hello *b)
@@ -138,6 +139,27 @@ static int test_fragment_shapes(void)
 	return 0;
 }
 
+static int test_minimal_tbnet_e2e_policy(void)
+{
+	tbv_tbnet_u32 peer_e2e =
+		TBV_TBNET_MINIMAL_BASE_PRTCSTNS | TBV_TBNET_PRTCSTNS_E2E;
+
+	if (tbv_tbnet_minimal_prtcstns(false) !=
+	    TBV_TBNET_MINIMAL_BASE_PRTCSTNS)
+		return 1;
+	if (tbv_tbnet_minimal_prtcstns(true) != peer_e2e)
+		return 2;
+	if (tbv_tbnet_minimal_e2e_enabled(false, peer_e2e))
+		return 3;
+	if (tbv_tbnet_minimal_e2e_enabled(true,
+					  TBV_TBNET_MINIMAL_BASE_PRTCSTNS))
+		return 4;
+	if (!tbv_tbnet_minimal_e2e_enabled(true, peer_e2e))
+		return 5;
+
+	return 0;
+}
+
 int main(void)
 {
 	unsigned char hello_buf[TBV_NATIVE_WIRE_HELLO_MSG_SIZE];
@@ -223,6 +245,8 @@ int main(void)
 		return 14;
 	if (test_fragment_shapes())
 		return 15;
+	if (test_minimal_tbnet_e2e_policy())
+		return 16;
 
 	puts("protocol header smoke OK");
 	return 0;

--- a/userspace/bench/tbv_uc_stress.py
+++ b/userspace/bench/tbv_uc_stress.py
@@ -42,6 +42,7 @@ CSV_FIELDS = [
     "repeat_count",
     "port",
     "connect_host",
+    "hold_before_destroy_ms",
     "status",
     "duration_s",
     "sender_rc",
@@ -69,6 +70,8 @@ WC_ERROR_RE = re.compile(
     r"recv wc error wr_id=\d+ status=(?P<status>\d+) "
     r"opcode=(?P<opcode>\d+) byte_len=(?P<byte_len>\d+)"
 )
+APPLE_RDMA_DEV_PREFIX = "rdma_"
+APPLE_RDMA_HOLD_BEFORE_DESTROY_MS = 1000
 
 
 def die(msg: str) -> None:
@@ -112,6 +115,34 @@ def safe_name(value: str) -> str:
     return value or "run"
 
 
+def apple_rdma_pair(receiver_dev: str, sender_dev: str) -> bool:
+    return receiver_dev.startswith(APPLE_RDMA_DEV_PREFIX) or sender_dev.startswith(
+        APPLE_RDMA_DEV_PREFIX
+    )
+
+
+def hold_before_destroy_ms(
+    args: argparse.Namespace, receiver_dev: str, sender_dev: str
+) -> int:
+    if args.hold_before_destroy_ms >= 0:
+        return args.hold_before_destroy_ms
+    if apple_rdma_pair(receiver_dev, sender_dev):
+        return APPLE_RDMA_HOLD_BEFORE_DESTROY_MS
+    return 0
+
+
+def host_tool(args: argparse.Namespace, host: str, role: str) -> str:
+    if host == args.server and args.server_tool:
+        return args.server_tool
+    if host == args.client and args.client_tool:
+        return args.client_tool
+    if role == "recv" and args.receiver_tool:
+        return args.receiver_tool
+    if role == "send" and args.sender_tool:
+        return args.sender_tool
+    return args.tool
+
+
 def uc_command(
     tool: str,
     *,
@@ -128,6 +159,7 @@ def uc_command(
     send_slots: int | None = None,
     recv_posts: int | None = None,
     connect: str | None = None,
+    hold_before_destroy_ms: int = 0,
 ) -> str:
     parts = [
         tool,
@@ -154,6 +186,8 @@ def uc_command(
         parts.extend(["--send-slots", str(send_slots)])
     if connect is not None:
         parts.extend(["--connect", connect])
+    if hold_before_destroy_ms:
+        parts.extend(["--hold-before-destroy-ms", str(hold_before_destroy_ms)])
     if check_any_order:
         parts.append("--check-any-order")
     elif check:
@@ -242,8 +276,8 @@ def run_case(
     port: int,
     log_dir: Path,
 ) -> dict[str, str]:
-    sender_tool = args.sender_tool or args.tool
-    receiver_tool = args.receiver_tool or args.tool
+    sender_tool = host_tool(args, sender, "send")
+    receiver_tool = host_tool(args, receiver, "recv")
     if args.connect_host:
         connect_host = args.connect_host
     elif receiver == args.server:
@@ -252,6 +286,7 @@ def run_case(
         connect_host = args.client_connect_host or receiver
     else:
         connect_host = receiver
+    hold_ms = hold_before_destroy_ms(args, receiver_dev, sender_dev)
     log_prefix = f"{safe_name(args.tag)}-" if args.tag else ""
     receiver_log = log_dir / (
         f"{log_prefix}{direction}-port{port}-size{size}-sd{send_depth}-mtu{mtu}-"
@@ -275,6 +310,7 @@ def run_case(
         mtu=mtu,
         check=args.check,
         check_any_order=args.check_any_order,
+        hold_before_destroy_ms=hold_ms,
     )
     send_cmd = uc_command(
         sender_tool,
@@ -290,6 +326,7 @@ def run_case(
         check=args.check,
         check_any_order=False,
         connect=connect_host,
+        hold_before_destroy_ms=hold_ms,
     )
 
     start = time.monotonic()
@@ -362,6 +399,7 @@ def run_case(
         "repeat_count": str(args.repeats),
         "port": str(port),
         "connect_host": connect_host,
+        "hold_before_destroy_ms": str(hold_ms),
         "status": "ok" if ok else "fail",
         "duration_s": f"{time.monotonic() - start:.3f}",
         "sender_rc": str(sender_rc),
@@ -392,6 +430,8 @@ def main() -> int:
     parser.add_argument("--server-gid-index", type=int, default=1)
     parser.add_argument("--client-gid-index", type=int, default=1)
     parser.add_argument("--tool", default="uc_oneway")
+    parser.add_argument("--server-tool", default="")
+    parser.add_argument("--client-tool", default="")
     parser.add_argument("--receiver-tool", default="")
     parser.add_argument("--sender-tool", default="")
     parser.add_argument(
@@ -427,6 +467,15 @@ def main() -> int:
     parser.add_argument("--timeout", type=float, default=90.0)
     parser.add_argument("--receiver-drain-timeout", type=float, default=10.0)
     parser.add_argument("--start-delay", type=float, default=1.0)
+    parser.add_argument(
+        "--hold-before-destroy-ms",
+        type=int,
+        default=-1,
+        help=(
+            "Pass uc_oneway --hold-before-destroy-ms; -1 selects 1000 ms for "
+            "Apple rdma_* devices and 0 otherwise."
+        ),
+    )
     parser.add_argument("--base-port", type=int, default=24000)
     parser.add_argument("--stop-on-fail", action="store_true")
     parser.add_argument("--no-check", dest="check", action="store_false")
@@ -445,6 +494,8 @@ def main() -> int:
         die("--send-depths must be positive")
     if args.send_slots < 0:
         die("--send-slots must be non-negative")
+    if args.hold_before_destroy_ms < -1:
+        die("--hold-before-destroy-ms must be -1 or non-negative")
 
     csv_path = Path(args.csv)
     log_dir = Path(args.log_dir) if args.log_dir else csv_path.with_suffix("")


### PR DESCRIPTION
Post-merge follow-up after #30.

Changes:
- Extract minimal ThunderboltIP E2E advertisement/ring-gating policy into `proto/tbnet.h` and make the kernel path use it.
- Add proto-smoke assertions for the exact bug we hit during integration: peer-advertised E2E must not enable E2E rings unless local `tbnet_identity_minimal_e2e` is set.
- Make `tbv_uc_stress.py` safer for Apple RDMA repeated runs: host-specific tool paths for `--directions both`, automatic 1000 ms `--hold-before-destroy-ms` for `rdma_*` Apple devices, and CSV recording of the hold.
- Repair the portable kernel patch check after #30 by trimming duplicate stale `xdomain.c` hunks from 0122 and dropping the stale route-trace debug patch from the portable bundle.

Validation:
- `nix flake check --builders '' --print-build-logs`
- `nix build .#thunderbolt-ibverbs-linux-thunderbolt --builders '' --print-out-paths`
- Live-loaded the new module on strix-2 and re-ran goblin <-> strix-2 checked Apple RDMA smokes.
- Exercised `tbv_uc_stress.py --directions both` with strix-2/goblin host-specific tools; CSV showed `hold_before_destroy_ms=1000` and both directions passed.