### PR TITLE
release: prepare v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker run --rm -it \
 
 # inside the container — pick .jammy for ubuntu 22.04, .noble for 24.04:
 apt install -y ibverbs-utils \
-    https://github.com/hellas-ai/thunderbolt-ibverbs/releases/latest/download/usb4-rdma-provider_0.2.1.jammy_amd64.deb
+    https://github.com/hellas-ai/thunderbolt-ibverbs/releases/latest/download/usb4-rdma-provider_0.3.0.jammy_amd64.deb
 
 ibv_devices
 # device          	   node GUID

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="thunderbolt-ibverbs"
-PACKAGE_VERSION="0.2.1"
+PACKAGE_VERSION="0.3.0"
 
 BUILT_MODULE_NAME[0]="thunderbolt_ibverbs"
 BUILT_MODULE_LOCATION[0]="kernel"

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
         pkgs:
         pkgs.stdenv.mkDerivation {
           pname = "thunderbolt-ibverbs-script-syntax";
-          version = "0.1.0";
+          version = "0.3.0";
           src = ./.;
 
           nativeBuildInputs = [ pkgs.bash ];
@@ -146,7 +146,7 @@
         in
         pkgs.stdenv.mkDerivation {
           pname = "thunderbolt-portable-kernel-patches-apply-check";
-          version = "0.1.0";
+          version = "0.3.0";
           src = pkgs.linuxPackages_latest.kernel.src;
 
           nativeBuildInputs = [ pkgs.git ];
@@ -180,7 +180,7 @@
         pkgs:
         pkgs.stdenv.mkDerivation {
           pname = "thunderbolt-ibverbs-proto-smoke";
-          version = "0.1.0";
+          version = "0.3.0";
           src = ./.;
 
           dontConfigure = true;
@@ -282,7 +282,7 @@
         pkgs:
         pkgs.stdenv.mkDerivation {
           pname = "thunderbolt-ibverbs-verbs-smoke-build";
-          version = "0.1.0";
+          version = "0.3.0";
           src = ./.;
 
           nativeBuildInputs = [ pkgs.pkg-config ];

--- a/nix/bench-tools.nix
+++ b/nix/bench-tools.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     if isDarwin
     then "thunderbolt-ibverbs-bench-tools-apple-rdma"
     else "thunderbolt-ibverbs-bench-tools";
-  version = "0.1.0";
+  version = "0.3.0";
 
   src = lib.cleanSourceWith {
     src = source;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -11,7 +11,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "thunderbolt-ibverbs";
-  version = "0.1.0";
+  version = "0.3.0";
 
   src = lib.cleanSourceWith {
     src = root;

--- a/packaging/rpm/thunderbolt-ibverbs-dkms.spec
+++ b/packaging/rpm/thunderbolt-ibverbs-dkms.spec
@@ -51,6 +51,11 @@ fi
 /usr/src/%{modname}-%{version}/*
 
 %changelog
+* Fri Jun 12 2026 George Whewell <george@hellas.ai> - 0.3.0-1
+- v0.3.0: correctness release with the reliability engine spine,
+  configfs link model, portable Thunderbolt patch stack, and Apple-compatible
+  transport hardening.
+
 * Sat May 30 2026 George Whewell <george@hellas.ai> - 0.2.1-1
 - v0.2.1: no DKMS-side changes; release cut alongside Ubuntu 22.04 and
   24.04 usb4-rdma-provider .debs so PyTorch / vllm / llama.cpp users can

--- a/packaging/rpm/usb4-rdma-provider.spec
+++ b/packaging/rpm/usb4-rdma-provider.spec
@@ -29,6 +29,10 @@ install -m 0644 %{_sourcedir}/usb4_rdma.driver %{buildroot}%{provider_etc_dir}/
 %{provider_etc_dir}/usb4_rdma.driver
 
 %changelog
+* Fri Jun 12 2026 George Whewell <george@hellas.ai> - 0.3.0-1
+- v0.3.0: release alongside thunderbolt-ibverbs correctness fixes and
+  refreshed kernel workflow packaging.
+
 * Sat May 30 2026 George Whewell <george@hellas.ai> - 0.2.1-1
 - v0.2.1: Ubuntu 22.04 / 24.04 .deb variants added alongside this rpm.
   Provider C backported with ifdef guards for rdma-core API drift

--- a/tools/ci/distro-build.sh
+++ b/tools/ci/distro-build.sh
@@ -141,7 +141,7 @@ build_userspace_smoke() {
 build_with_dkms() {
 	local kver="$1"
 	local pkg="thunderbolt-ibverbs"
-	local ver="0.1.0"
+	local ver="0.3.0"
 	local dkms_src="/usr/src/$pkg-$ver"
 	local built
 


### PR DESCRIPTION
## Summary
- bump DKMS, Nix package, and distro smoke versions to 0.3.0
- update README provider package URL to the 0.3.0 release asset name
- add 0.3.0 RPM changelog entries

## Validation
- nix flake check --builders '' --print-build-logs
- nix build .#thunderbolt-ibverbs-linux-thunderbolt --builders '' --print-out-paths --print-build-logs