### PR TITLE
apple: verify raw RX chunk CRC

### DIFF
--- a/kernel/debugfs.c
+++ b/kernel/debugfs.c
@@ -365,6 +365,8 @@ static int tbv_debugfs_summary_show(struct seq_file *s, void *unused)
 		   atomic64_read(&state->apple_rx_eof_without_active));
 	seq_printf(s, "apple_rx_len_overrun: %lld\n",
 		   atomic64_read(&state->apple_rx_len_overrun));
+	seq_printf(s, "apple_rx_raw_crc_error: %lld\n",
+		   atomic64_read(&state->apple_rx_raw_crc_error));
 	seq_printf(s, "apple_rx_resync_dropped: %lld\n",
 		   atomic64_read(&state->apple_rx_resync_dropped));
 	seq_printf(s, "apple_rx_rail_mismatch: %lld\n",

--- a/kernel/ibdev.c
+++ b/kernel/ibdev.c
@@ -5639,9 +5639,15 @@ static int tbv_apple_rx_copy_piece_to_buf(struct tbv_qp *tqp,
 	return 0;
 }
 
+static bool tbv_apple_rx_raw_crc_trailer(u8 eof)
+{
+	return eof == 2 || eof == 3;
+}
+
 static int tbv_apple_rx_wire_user_len(u32 len, u8 eof, u32 *user_len)
 {
-	if (tbv_path_apple_rx_raw_mode() && (eof == 2 || eof == 3)) {
+	if (tbv_path_apple_rx_raw_mode() &&
+	    tbv_apple_rx_raw_crc_trailer(eof)) {
 		if (len < sizeof(__le32))
 			return -EINVAL;
 		*user_len = len - sizeof(__le32);
@@ -5649,6 +5655,32 @@ static int tbv_apple_rx_wire_user_len(u32 len, u8 eof, u32 *user_len)
 		*user_len = len;
 	}
 	return 0;
+}
+
+static int tbv_apple_rx_verify_raw_crc(struct tbv_apple_pending_rx *p,
+				       const void *payload, u32 len, u8 eof)
+{
+	const u8 *chunk;
+	__le32 expected_le;
+	u32 expected;
+	u32 actual;
+
+	if (!tbv_path_apple_rx_raw_mode() ||
+	    !tbv_apple_rx_raw_crc_trailer(eof))
+		return 0;
+	if (len < sizeof(expected_le) || !p->buf)
+		return -EINVAL;
+	if (p->delivered < TBV_APPLE_FRAME_SIZE ||
+	    p->delivered % TBV_APPLE_FRAME_SIZE)
+		return -EPROTO;
+
+	memcpy(&expected_le, (const u8 *)payload + len - sizeof(expected_le),
+	       sizeof(expected_le));
+	expected = le32_to_cpu(expected_le);
+	chunk = (const u8 *)p->buf + p->delivered - TBV_APPLE_FRAME_SIZE;
+	actual = crc32c(~0u, chunk, TBV_APPLE_FRAME_SIZE) ^ ~0u;
+
+	return actual == expected ? 0 : -EBADMSG;
 }
 
 static int tbv_apple_rx_copy_frame_to_buf(struct tbv_qp *tqp,
@@ -5666,6 +5698,9 @@ static int tbv_apple_rx_copy_frame_to_buf(struct tbv_qp *tqp,
 
 	ret = tbv_apple_rx_copy_piece_to_buf(tqp, p, payload, copy_len,
 					     &user_len);
+	if (ret)
+		return ret;
+	ret = tbv_apple_rx_verify_raw_crc(p, payload, len, eof);
 	if (ret)
 		return ret;
 	*out_user_len = user_len;
@@ -5782,6 +5817,9 @@ void tbv_ibdev_rx_apple_frame(struct tbv_state *state,
 					     &user_len);
 	if (ret) {
 		atomic64_inc(&state->data_rx_bad_frame);
+		if (tbv_path_apple_rx_raw_mode() &&
+		    tbv_apple_rx_raw_crc_trailer(eof))
+			atomic64_inc(&state->apple_rx_raw_crc_error);
 		pending->status = (ret == -EMSGSIZE || ret == -ENOSPC) ?
 			IB_WC_LOC_LEN_ERR : IB_WC_LOC_PROT_ERR;
 	}

--- a/kernel/tbv.h
+++ b/kernel/tbv.h
@@ -592,6 +592,7 @@ struct tbv_state {
 	atomic64_t apple_rx_no_sof_when_idle;
 	atomic64_t apple_rx_eof_without_active;
 	atomic64_t apple_rx_len_overrun;
+	atomic64_t apple_rx_raw_crc_error;
 	atomic64_t apple_rx_resync_dropped;
 	atomic64_t apple_rx_rail_mismatch;
 	atomic64_t apple_rx_cq_overflow;

--- a/tools/ci/proto-smoke.c
+++ b/tools/ci/proto-smoke.c
@@ -1,9 +1,66 @@
 // SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "proto/native_data.h"
 #include "proto/tbnet.h"
+
+#define APPLE_RAW_CHUNK_SIZE 4096u
+#define APPLE_RAW_TAIL_USER_SIZE 240u
+#define APPLE_RAW_TAIL_WIRE_SIZE (APPLE_RAW_TAIL_USER_SIZE + sizeof(uint32_t))
+
+static uint32_t smoke_crc32c(uint32_t seed, const void *data, size_t len)
+{
+	const unsigned char *p = data;
+	uint32_t crc = seed;
+	size_t i;
+
+	while (len--) {
+		crc ^= *p++;
+		for (i = 0; i < 8; i++)
+			crc = (crc >> 1) ^ (0x82f63b78u & -(crc & 1u));
+	}
+
+	return crc;
+}
+
+static void put_le32(unsigned char *dst, uint32_t value)
+{
+	dst[0] = (unsigned char)value;
+	dst[1] = (unsigned char)(value >> 8);
+	dst[2] = (unsigned char)(value >> 16);
+	dst[3] = (unsigned char)(value >> 24);
+}
+
+static uint32_t get_le32(const unsigned char *src)
+{
+	return (uint32_t)src[0] |
+	       ((uint32_t)src[1] << 8) |
+	       ((uint32_t)src[2] << 16) |
+	       ((uint32_t)src[3] << 24);
+}
+
+static int apple_raw_verify_crc_model(const unsigned char *assembled,
+				      unsigned int delivered,
+				      const unsigned char *tail_wire,
+				      unsigned int tail_wire_len)
+{
+	uint32_t expected;
+	uint32_t actual;
+
+	if (tail_wire_len < sizeof(expected) ||
+	    delivered < APPLE_RAW_CHUNK_SIZE ||
+	    delivered % APPLE_RAW_CHUNK_SIZE)
+		return -1;
+
+	expected = get_le32(tail_wire + tail_wire_len - sizeof(expected));
+	actual = smoke_crc32c(~0u, assembled + delivered -
+			      APPLE_RAW_CHUNK_SIZE,
+			      APPLE_RAW_CHUNK_SIZE) ^ ~0u;
+
+	return actual == expected ? 0 : -1;
+}
 
 static int hello_equal(const struct tbv_native_wire_hello *a,
 		       const struct tbv_native_wire_hello *b)
@@ -160,6 +217,47 @@ static int test_minimal_tbnet_e2e_policy(void)
 	return 0;
 }
 
+static int test_apple_raw_crc_model(void)
+{
+	unsigned char assembled[APPLE_RAW_CHUNK_SIZE * 2];
+	unsigned char tail[APPLE_RAW_TAIL_WIRE_SIZE];
+	uint32_t crc;
+	unsigned int i;
+
+	for (i = 0; i < sizeof(assembled); i++)
+		assembled[i] = (unsigned char)((i * 17u + 3u) & 0xffu);
+	memcpy(tail, assembled + APPLE_RAW_CHUNK_SIZE -
+	       APPLE_RAW_TAIL_USER_SIZE, APPLE_RAW_TAIL_USER_SIZE);
+	crc = smoke_crc32c(~0u, assembled, APPLE_RAW_CHUNK_SIZE) ^ ~0u;
+	put_le32(tail + APPLE_RAW_TAIL_USER_SIZE, crc);
+
+	if (apple_raw_verify_crc_model(assembled, APPLE_RAW_CHUNK_SIZE, tail,
+				       sizeof(tail)))
+		return 1;
+
+	tail[APPLE_RAW_TAIL_USER_SIZE] ^= 0x01;
+	if (!apple_raw_verify_crc_model(assembled, APPLE_RAW_CHUNK_SIZE, tail,
+					sizeof(tail)))
+		return 2;
+	tail[APPLE_RAW_TAIL_USER_SIZE] ^= 0x01;
+
+	if (!apple_raw_verify_crc_model(assembled, APPLE_RAW_CHUNK_SIZE - 1,
+					tail, sizeof(tail)))
+		return 3;
+	if (!apple_raw_verify_crc_model(assembled, APPLE_RAW_CHUNK_SIZE, tail,
+					sizeof(uint32_t) - 1))
+		return 4;
+
+	crc = smoke_crc32c(~0u, assembled + APPLE_RAW_CHUNK_SIZE,
+			   APPLE_RAW_CHUNK_SIZE) ^ ~0u;
+	put_le32(tail + APPLE_RAW_TAIL_USER_SIZE, crc);
+	if (apple_raw_verify_crc_model(assembled, APPLE_RAW_CHUNK_SIZE * 2,
+				       tail, sizeof(tail)))
+		return 5;
+
+	return 0;
+}
+
 int main(void)
 {
 	unsigned char hello_buf[TBV_NATIVE_WIRE_HELLO_MSG_SIZE];
@@ -247,6 +345,8 @@ int main(void)
 		return 15;
 	if (test_minimal_tbnet_e2e_policy())
 		return 16;
+	if (test_apple_raw_crc_model())
+		return 17;
 
 	puts("protocol header smoke OK");
 	return 0;


### PR DESCRIPTION
## Summary
- verify the CRC32C trailer on Apple raw RX chunks before accepting assembled data
- expose `apple_rx_raw_crc_error` in debugfs for raw-mode integrity failures
- add a CI smoke model for good, corrupted, short, and misaligned raw chunk trailers

## Validation
- `git diff --check`
- `nix flake check --no-build --builders '\ --print-build-logs`\n- `nix build .#checks.x86_64-linux.proto-smoke --builders '\ --no-link --print-build-logs`\n- `nix build .#packages.x86_64-linux.thunderbolt-ibverbs-linux-thunderbolt --builders '\ --no-link --print-build-logs`\n- strix-1 <-> goblin framed Apple UC smoke after reload:\n  - goblin -> strix-1: 256 x 4096 checked, 256/256, zero `data_rx_bad_frame`, zero Apple error counters\n  - strix-1 -> goblin: 256 x 4096 checked, 256/256, zero TX/RX error counters\n- raw RX diagnostic on strix-1 with `apple_rx_raw_mode=1` rejected macOS traffic with `apple_rx_raw_crc_error=2` and a recv protection error, confirming raw mode no longer silently accepts unchecked trailer data. Framed mode was restored afterward (`rx_flags=0x6`).