### PR TITLE
ci: update release workflow actions

### DIFF
--- a/.github/workflows/release-artefacts.yml
+++ b/.github/workflows/release-artefacts.yml
@@ -59,7 +59,7 @@ jobs:
             rdma_glob: 'dist/usb4-rdma-provider_*~noble_amd64.deb'
             upload_glob: 'dist/usb4-rdma-provider_*~noble_amd64.deb'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build DKMS package in ${{ matrix.image }}
         if: matrix.build_dkms
@@ -100,7 +100,7 @@ jobs:
             bash tools/ci/distro-install.sh '${{ matrix.rdma_glob }}'
 
       - name: Upload artefacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: thunderbolt-ibverbs-${{ matrix.name }}
           path: ${{ matrix.upload_glob }}
@@ -114,10 +114,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
## Summary
- update release workflow to current official action majors: `checkout@v6`, `upload-artifact@v7`, `download-artifact@v8`
- removes the Node 20 deprecation warning seen on the v0.3.2 release workflow

## Validation
- `actionlint .github/workflows/release-artefacts.yml`
- `git diff --check`
- `nix build .#checks.x86_64-linux.script-syntax --builders '\ --no-link --print-build-logs`\n- verified upstream tags exist for `actions/checkout@v6`, `actions/upload-artifact@v7`, and `actions/download-artifact@v8`