### PR TITLE
apple: disable unsafe raw RX mode

### DIFF
--- a/kernel/path.c
+++ b/kernel/path.c
@@ -78,7 +78,7 @@ MODULE_PARM_DESC(apple_tx_e2e,
 static bool apple_rx_raw_mode;
 module_param(apple_rx_raw_mode, bool, 0644);
 MODULE_PARM_DESC(apple_rx_raw_mode,
-		 "Use RAW descriptors for Apple-compatible RX rings; default keeps FRAME reassembly");
+		 "Compatibility no-op: Apple RAW RX is disabled because raw descriptor boundaries are not yet message-safe");
 
 static uint native_tx_max_inflight = TBV_DATA_TX_MAX_INFLIGHT;
 module_param(native_tx_max_inflight, uint, 0644);
@@ -543,7 +543,9 @@ bool tbv_path_apple_tx_raw_mode(void)
 
 bool tbv_path_apple_rx_raw_mode(void)
 {
-	return READ_ONCE(apple_rx_raw_mode);
+	if (READ_ONCE(apple_rx_raw_mode))
+		pr_warn_once("apple_rx_raw_mode is ignored: Apple RAW RX descriptor boundaries are not message-safe\n");
+	return false;
 }
 
 void tbv_path_default_config(enum tbv_backend_type backend,


### PR DESCRIPTION
## Summary
- keep the `apple_rx_raw_mode` parameter for compatibility, but ignore it and force Apple RX rings to framed mode
- emit a one-time warning when raw RX is requested
- this avoids an opt-in path that can merge raw descriptors across message boundaries

## Evidence
- v0.3.2 raw RX with goblin -> strix-1, 256 x 4096, reproduced `IB_WC_LOC_LEN_ERR` at `wr_id=63`, `apple_rx_len_overrun=1`, `apple_rx_raw_crc_error=1`
- raw trace around the failure showed a message receiving 256-byte raw descriptors past 4096 bytes without the expected message EOF, so framed reassembly is the only currently validated Apple RX path

## Validation
- `git diff --check`
- `nix flake check --no-build --builders '\ --print-build-logs`\n- `nix build .#packages.x86_64-linux.thunderbolt-ibverbs-linux-thunderbolt --builders '\ --no-link --print-build-logs`\n- `nix build .#checks.x86_64-linux.proto-smoke .#checks.x86_64-linux.script-syntax --builders '\ --no-link --print-build-logs`\n- strix-1 test build loaded with `apple_rx_raw_mode=1`: module parameter reads `Y`, but Apple path stayed framed (`rx_flags=0x6`) and logged `apple_rx_raw_mode is ignored`\n- goblin -> strix-1 with `apple_rx_raw_mode=1` ignored: 128 x 4096 checked, 128/128, zero `data_rx_bad_frame`, zero `apple_rx_len_overrun`, zero `apple_rx_raw_crc_error`\n- strix-1 restored afterward to published v0.3.2 framed mode (`apple_rx_raw_mode=N`, `rx_flags=0x6`)