### PR TITLE
apple: let single-frame TX fill frame window

### DIFF
--- a/kernel/ibdev.c
+++ b/kernel/ibdev.c
@@ -101,7 +101,11 @@ MODULE_PARM_DESC(qp_timeout_ms,
 		 "Fallback milliseconds for pending native/Apple WRs and partial native receives "
 		 "when a QP has no verbs ACK timeout; 0 disables fallback timeout work");
 
-static uint apple_tx_max_inflight_wr = 1;
+/*
+ * Single-frame SENDs are self-delimiting and can safely fill the existing
+ * frame window. Multi-frame SENDs still take an exclusive window below.
+ */
+static uint apple_tx_max_inflight_wr = TBV_APPLE_TX_MAX_INFLIGHT_FRAMES_DEFAULT;
 module_param(apple_tx_max_inflight_wr, uint, 0644);
 MODULE_PARM_DESC(apple_tx_max_inflight_wr,
 		 "Maximum Apple-compatible single-frame UC SEND work requests in flight per QP; multi-frame SENDs are serialized by protocol");


### PR DESCRIPTION
## Summary
- change the Apple UC default `apple_tx_max_inflight_wr` from stop-and-wait to the existing frame-window default
- keep multi-frame SENDs on the exclusive-window path; this only affects self-delimiting single-frame SENDs

## Validation
- `git diff --check`
- `nix flake check --no-build --builders '\ --print-build-logs`\n- `nix build .#packages.x86_64-linux.thunderbolt-ibverbs-linux-thunderbolt --builders '\ --no-link --print-out-paths --print-build-logs`\n- loaded the built module on `strix-1` without passing `apple_tx_max_inflight_wr`; confirmed runtime default `wr=4`, `frames=4`\n- `goblin -> strix-1`: 512 x 4 KiB checked UC SENDs passed; Linux RX counters clean\n- `strix-1 -> goblin`: 4000 x 4 KiB checked UC SENDs passed at ~5.7 Gbit/s; Linux TX counters clean\n- `strix-1 -> goblin`: 32 x 64 KiB checked UC SENDs passed; multi-frame exclusive path counters clean\n- after restoring `strix-1` to the released v0.3.3 module, `goblin -> strix-1`: 63 x 64 KiB checked UC SENDs passed at ~14.7 Gbit/s with Linux RX counters clean\n\nNotes from comparison testing:\n- `goblin -> mbp` at 128 x 64 KiB did not start because macOS failed `ibv_post_recv[63/128] ret=-12`; the same Mac-to-Mac path passes at 63 x 64 KiB\n- the earlier `goblin -> strix-1` 128 x 64 KiB attempt failed in macOS `ibv_post_send` after 49 delivered messages; Linux recorded no bad frames, length errors, CQ overflow, rail mismatch, or resync drops\n