### PR TITLE
apple: shorten minimal login retry cadence

### DIFF
--- a/kernel/tbnet_minimal.c
+++ b/kernel/tbnet_minimal.c
@@ -35,7 +35,12 @@
 #include "tbv.h"
 #include "proto/tbnet.h"
 
-#define TBV_TBNET_MIN_LOGIN_DELAY_MS	4500
+/*
+ * macOS may keep a half-open ThunderboltIP state across module reloads; retry
+ * the LOGIN/LOGOUT reset cadence promptly so Apple rail publication is not
+ * held behind a multi-second backoff.
+ */
+#define TBV_TBNET_MIN_LOGIN_DELAY_MS	1000
 #define TBV_TBNET_MIN_LOGIN_TIMEOUT_MS	500
 #define TBV_TBNET_MIN_LOGIN_RETRIES	60
 #define TBV_TBNET_MIN_LOGOUT_TIMEOUT_MS	1000


### PR DESCRIPTION
## Summary
- reduce the minimal ThunderboltIP LOGIN/LOGOUT retry cadence from 4.5s to 1s
- keep the existing retry-count and protocol flow; this only removes the multi-second backoff that delays Apple rail publication after reload

## Validation
- `git diff --check`
- `nix build .#packages.x86_64-linux.thunderbolt-ibverbs-linux-thunderbolt --builders '\ --no-link --print-out-paths --print-build-logs`\n- baseline v0.3.3 on `strix-1 <-> goblin`: 5/5 module reload cycles published `usb4_rdma4`, each ~5.5s, `tbnet_identity_minimal_path_errors=0`\n- patched module on `strix-1 <-> goblin`: 5/5 module reload cycles published `usb4_rdma4`, ~1.9-2.2s, `tbnet_identity_minimal_path_errors=0`\n- patched module `goblin -> strix-1`: 512 x 4 KiB checked UC SENDs passed; Linux RX counters clean\n- patched module `strix-1 -> goblin`: 512 x 4 KiB checked UC SENDs passed; Linux TX/RX counters clean\n\nNote: `tbnet_identity_minimal_neighbor_seen` remains 0 in this mode because it tracks proxy IPv4 packet/ARP activity, not reciprocal LOGIN or Apple rail readiness. Apple rail publication uses minimal packet-path readiness.\n