### PR TITLE
apple: serialize all UC SENDs per QP

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -48,7 +48,7 @@ help:
 	@echo "  register_verbs=0|1"
 	@echo "  native_prtcstns=<u32>"
 	@echo "  apple_prtcstns=<u32>"
-	@echo "  apple_tx_max_inflight_wr=<N>"
+	@echo "  apple_tx_max_inflight_wr=<N>    deprecated compatibility knob; Apple SENDs serialize per QP"
 	@echo "  apple_tx_max_inflight_frames=<N>"
 	@echo "  apple_rx_pending_bytes=<bytes>"
 	@echo "  apple_rx_pending_slots=<N>"

--- a/kernel/ibdev.c
+++ b/kernel/ibdev.c
@@ -32,6 +32,7 @@
 #include <rdma/ib_user_verbs.h>
 #include <rdma/ib_verbs.h>
 
+#include "../proto/apple_tx.h"
 #include "../proto/native_data.h"
 #include "../proto/reliability.h"
 #include "tbv.h"
@@ -101,14 +102,10 @@ MODULE_PARM_DESC(qp_timeout_ms,
 		 "Fallback milliseconds for pending native/Apple WRs and partial native receives "
 		 "when a QP has no verbs ACK timeout; 0 disables fallback timeout work");
 
-/*
- * Single-frame SENDs are self-delimiting and can safely fill the existing
- * frame window. Multi-frame SENDs still take an exclusive window below.
- */
 static uint apple_tx_max_inflight_wr = TBV_APPLE_TX_MAX_INFLIGHT_FRAMES_DEFAULT;
 module_param(apple_tx_max_inflight_wr, uint, 0644);
 MODULE_PARM_DESC(apple_tx_max_inflight_wr,
-		 "Maximum Apple-compatible single-frame UC SEND work requests in flight per QP; multi-frame SENDs are serialized by protocol");
+		 "Deprecated: Apple-compatible UC SENDs are serialized per QP; retained for compatibility");
 
 static uint apple_tx_max_inflight_frames =
 	TBV_APPLE_TX_MAX_INFLIGHT_FRAMES_DEFAULT;
@@ -6160,24 +6157,6 @@ static void tbv_qp_return_remote_recv_credit(struct tbv_qp *tqp)
 	wake_up_all(&tqp->credit_wait);
 }
 
-static u32 tbv_apple_tx_frame_charge(u32 frames, unsigned int max_frames)
-{
-	if (!max_frames)
-		return 0;
-	return min_t(u32, frames, max_frames);
-}
-
-static bool tbv_apple_tx_requires_exclusive_window(u32 frames)
-{
-	/*
-	 * Apple FA57 RX frames carry SOF/EOF but no message sequence. Multiple
-	 * multi-frame SENDs in flight can therefore interleave at the peer and
-	 * produce partial or misassembled WQEs. Single-frame SENDs are self
-	 * delimiting and may still use the normal software window.
-	 */
-	return frames > 1;
-}
-
 static bool tbv_qp_apple_tx_window_ok_locked(struct tbv_qp *tqp,
 					     bool exclusive,
 					     unsigned int max_wr,
@@ -6187,9 +6166,8 @@ static bool tbv_qp_apple_tx_window_ok_locked(struct tbv_qp *tqp,
 	int cur_wr = atomic_read(&tqp->apple_tx_inflight);
 	int cur_frames = atomic_read(&tqp->apple_tx_inflight_frames);
 
-	return (exclusive ? !cur_wr : (!max_wr || cur_wr < max_wr)) &&
-	       (!exclusive || !cur_frames) &&
-	       (!max_frames || cur_frames + frame_charge <= max_frames);
+	return tbv_apple_tx_window_ok(cur_wr, cur_frames, exclusive, max_wr,
+				      max_frames, frame_charge);
 }
 
 static bool tbv_qp_try_acquire_apple_tx_window(struct tbv_qp *tqp, u32 frames,

--- a/proto/apple_tx.h
+++ b/proto/apple_tx.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause */
+#ifndef TBV_APPLE_TX_H
+#define TBV_APPLE_TX_H
+
+#ifdef __KERNEL__
+#include <linux/types.h>
+typedef u32 tbv_apple_tx_u32;
+#else
+#include <stdbool.h>
+#include <stdint.h>
+typedef uint32_t tbv_apple_tx_u32;
+#endif
+
+static inline tbv_apple_tx_u32
+tbv_apple_tx_frame_charge(tbv_apple_tx_u32 frames,
+			  tbv_apple_tx_u32 max_frames)
+{
+	if (!max_frames)
+		return 0;
+	return frames < max_frames ? frames : max_frames;
+}
+
+static inline bool
+tbv_apple_tx_requires_exclusive_window(tbv_apple_tx_u32 frames)
+{
+	/*
+	 * Apple FA57 RX frames carry SOF/EOF but no message sequence or
+	 * incarnation. Keep every non-empty SEND on an exclusive per-QP window
+	 * so Linux does not emit concurrent messages that macOS can
+	 * mis-associate or drop under short-message bursts.
+	 */
+	return frames > 0;
+}
+
+static inline bool
+tbv_apple_tx_window_ok(int cur_wr, int cur_frames, bool exclusive,
+		       unsigned int max_wr, unsigned int max_frames,
+		       tbv_apple_tx_u32 frame_charge)
+{
+	if (cur_wr < 0 || cur_frames < 0)
+		return false;
+
+	if (exclusive) {
+		if (cur_wr || cur_frames)
+			return false;
+	} else if (max_wr && cur_wr >= (int)max_wr) {
+		return false;
+	}
+
+	if (max_frames &&
+	    (tbv_apple_tx_u32)cur_frames + frame_charge > max_frames)
+		return false;
+
+	return true;
+}
+
+#endif /* TBV_APPLE_TX_H */

--- a/tools/ci/proto-smoke.c
+++ b/tools/ci/proto-smoke.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "proto/apple_tx.h"
 #include "proto/native_data.h"
 #include "proto/tbnet.h"
 
@@ -258,6 +259,51 @@ static int test_apple_raw_crc_model(void)
 	return 0;
 }
 
+static int test_apple_tx_window_policy(void)
+{
+	tbv_apple_tx_u32 single_charge = tbv_apple_tx_frame_charge(1, 4);
+	tbv_apple_tx_u32 multi_charge = tbv_apple_tx_frame_charge(17, 4);
+
+	if (tbv_apple_tx_requires_exclusive_window(0))
+		return 1;
+	if (!tbv_apple_tx_requires_exclusive_window(1))
+		return 2;
+	if (!tbv_apple_tx_requires_exclusive_window(17))
+		return 3;
+
+	if (single_charge != 1)
+		return 4;
+	if (multi_charge != 4)
+		return 5;
+	if (tbv_apple_tx_frame_charge(17, 0) != 0)
+		return 6;
+
+	if (!tbv_apple_tx_window_ok(0, 0, true, 4, 4, single_charge))
+		return 7;
+	if (tbv_apple_tx_window_ok(1, 0, true, 4, 4, single_charge))
+		return 8;
+	if (tbv_apple_tx_window_ok(0, 1, true, 4, 4, single_charge))
+		return 9;
+	if (!tbv_apple_tx_window_ok(0, 0, true, 0, 0, 0))
+		return 10;
+
+	if (!tbv_apple_tx_window_ok(0, 0, true, 4, 4, multi_charge))
+		return 11;
+	if (tbv_apple_tx_window_ok(0, 1, true, 4, 4, multi_charge))
+		return 12;
+
+	if (!tbv_apple_tx_window_ok(3, 0, false, 4, 4, 0))
+		return 13;
+	if (tbv_apple_tx_window_ok(4, 0, false, 4, 4, 0))
+		return 14;
+	if (tbv_apple_tx_window_ok(-1, 0, true, 4, 4, single_charge))
+		return 15;
+	if (tbv_apple_tx_window_ok(0, -1, true, 4, 4, single_charge))
+		return 16;
+
+	return 0;
+}
+
 int main(void)
 {
 	unsigned char hello_buf[TBV_NATIVE_WIRE_HELLO_MSG_SIZE];
@@ -347,6 +393,8 @@ int main(void)
 		return 16;
 	if (test_apple_raw_crc_model())
 		return 17;
+	if (test_apple_tx_window_policy())
+		return 18;
 
 	puts("protocol header smoke OK");
 	return 0;


### PR DESCRIPTION
## Summary
- remove the single-frame Apple UC SEND fast path from TX admission
- route every non-empty Apple UC SEND through the same exclusive per-QP window because FA57 has no message sequence/incarnation and Linux -> macOS short SEND bursts have shown corruption/timeouts
- factor the admission rule into `proto/apple_tx.h` and cover it in `tools/ci/proto-smoke.c`
- retain `apple_tx_max_inflight_wr` as a deprecated compatibility parameter so existing reload/deploy options keep working, and label it as deprecated in `make help`

## Validation completed
- `git diff --check origin/main...HEAD`
- `nix build .#checks.x86_64-linux.proto-smoke --builders '' --no-link --print-build-logs`
- `nix build .#packages.x86_64-linux.thunderbolt-ibverbs-linux-thunderbolt --builders '' --no-link --print-build-logs`
- `nix flake check --no-build --builders '' --print-build-logs`
- GitHub release-artefact build matrix: green
- Hydra: `ci/evaluation`, `ci/module`, `ci/aarch64/userspace` green

## Hardware validation still needed
Current topology still does not expose a Linux <-> macOS Apple path:
- strix-1 and strix-2 only enumerate each other as a native Linux peer with two rails
- router has no Thunderbolt peer and `apple_service_registered: 0`
- goblin only has `rdma_en3` active for the goblin <-> mbp Apple-native path; stale `en4` addresses are not backed by an active RDMA port
- mbp is reachable through goblin and only exposes the goblin <-> mbp Apple-native path plus the QNAP adapter

Before merge, replug a strix <-> goblin path and run the repeatable gate from #45:

```sh
python userspace/bench/tbv_uc_stress.py \
  --server strix-1 \
  --client goblin \
  --server-dev usb4_rdma4 \
  --client-dev rdma_en4 \
  --server-connect-host 192.168.23.136 \
  --client-connect-host 192.168.23.247 \
  --apple-gate \
  --base-port 19100 \
  --csv /tmp/tbv-apple-gate-strix-goblin/results.csv \
  --log-dir /tmp/tbv-apple-gate-strix-goblin/logs
```

Use the actual device names after the strix <-> goblin path appears; the command above is the expected shape, not proof that the current topology is usable.
