### PR TITLE
bench: add Apple UC gate preset

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,10 @@
           version = "0.3.4";
           src = ./.;
 
-          nativeBuildInputs = [ pkgs.bash ];
+          nativeBuildInputs = [
+            pkgs.bash
+            pkgs.python3
+          ];
 
           dontConfigure = true;
 
@@ -118,6 +121,10 @@
               tools/ci/vm-guest-smoke.sh \
               tools/ci/vm-smoke.sh \
               userspace/bench/tbv_vllm_smoke.sh
+            python -m py_compile \
+              userspace/bench/tbv_perftest_runner.py \
+              userspace/bench/tbv_rdma_sweep.py \
+              userspace/bench/tbv_uc_stress.py
             runHook postBuild
           '';
 

--- a/userspace/bench/tbv_uc_stress.py
+++ b/userspace/bench/tbv_uc_stress.py
@@ -122,9 +122,11 @@ def apple_rdma_pair(receiver_dev: str, sender_dev: str) -> bool:
     )
 
 
-def apple_queue_depth(value: int, receiver_dev: str, sender_dev: str) -> int:
-    if apple_rdma_pair(receiver_dev, sender_dev):
-        return min(value, APPLE_UC_QUEUE_DEPTH)
+def apple_queue_depth(
+    value: int, receiver_dev: str, sender_dev: str, apple_limit: int
+) -> int:
+    if apple_limit and apple_rdma_pair(receiver_dev, sender_dev):
+        return min(value, apple_limit)
     return value
 
 
@@ -294,11 +296,19 @@ def run_case(
     else:
         connect_host = receiver
     hold_ms = hold_before_destroy_ms(args, receiver_dev, sender_dev)
-    recv_depth = apple_queue_depth(args.recv_depth, receiver_dev, sender_dev)
-    recv_posts = apple_queue_depth(args.recv_posts, receiver_dev, sender_dev)
-    send_depth = apple_queue_depth(send_depth, receiver_dev, sender_dev)
+    recv_depth = apple_queue_depth(
+        args.recv_depth, receiver_dev, sender_dev, args.apple_queue_depth
+    )
+    recv_posts = apple_queue_depth(
+        args.recv_posts, receiver_dev, sender_dev, args.apple_queue_depth
+    )
+    send_depth = apple_queue_depth(
+        send_depth, receiver_dev, sender_dev, args.apple_queue_depth
+    )
     send_slots = args.send_slots or send_depth
-    send_slots = apple_queue_depth(send_slots, receiver_dev, sender_dev)
+    send_slots = apple_queue_depth(
+        send_slots, receiver_dev, sender_dev, args.apple_queue_depth
+    )
     if args.check and send_slots < send_depth:
         send_slots = send_depth
     log_prefix = f"{safe_name(args.tag)}-" if args.tag else ""
@@ -478,6 +488,24 @@ def main() -> int:
     parser.add_argument("--mtus", type=parse_csv_ints, default=parse_csv_ints("4096"))
     parser.add_argument("--count", type=int, default=100000)
     parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument(
+        "--apple-queue-depth",
+        type=int,
+        default=APPLE_UC_QUEUE_DEPTH,
+        help=(
+            "Maximum requested depth for cases involving macOS rdma_* devices; "
+            "0 disables this software cap."
+        ),
+    )
+    parser.add_argument(
+        "--apple-gate",
+        action="store_true",
+        help=(
+            "Run the Apple compatibility merge-gate matrix: both directions, "
+            "4 KiB and 64 KiB checked SENDs, depth/count 256, strict order, "
+            "and fail-fast."
+        ),
+    )
     parser.add_argument("--timeout", type=float, default=90.0)
     parser.add_argument("--receiver-drain-timeout", type=float, default=10.0)
     parser.add_argument("--start-delay", type=float, default=1.0)
@@ -498,6 +526,32 @@ def main() -> int:
     parser.set_defaults(check=True, check_any_order=True)
     args = parser.parse_args()
 
+    if args.apple_gate:
+        args.directions = "both"
+        args.sizes = [4096, 65536]
+        args.send_depths = [256]
+        args.send_slots = 256
+        args.recv_depth = 256
+        args.recv_posts = 256
+        args.mtus = [4096]
+        args.count = 256
+        args.repeats = 1
+        args.apple_queue_depth = 256
+        args.timeout = max(args.timeout, 120.0)
+        args.receiver_drain_timeout = max(args.receiver_drain_timeout, 30.0)
+        args.hold_before_destroy_ms = max(args.hold_before_destroy_ms, 1500)
+        args.stop_on_fail = True
+        args.check = True
+        args.check_any_order = False
+        if not args.tag:
+            args.tag = "apple-gate"
+        print(
+            "tbv-uc-stress: apple gate preset active "
+            "(both directions, sizes=4096,65536, depth=256, count=256, "
+            "strict-order)",
+            flush=True,
+        )
+
     if args.count <= 0:
         die("--count must be positive")
     if args.repeats <= 0:
@@ -508,6 +562,8 @@ def main() -> int:
         die("--send-depths must be positive")
     if args.send_slots < 0:
         die("--send-slots must be non-negative")
+    if args.apple_queue_depth < 0:
+        die("--apple-queue-depth must be non-negative")
     if args.hold_before_destroy_ms < -1:
         die("--hold-before-destroy-ms must be -1 or non-negative")
 
@@ -581,10 +637,16 @@ def main() -> int:
                             run_index += 1
                             port = args.base_port + run_index
                             effective_send_depth = apple_queue_depth(
-                                send_depth, receiver_dev, sender_dev
+                                send_depth,
+                                receiver_dev,
+                                sender_dev,
+                                args.apple_queue_depth,
                             )
                             effective_recv_posts = apple_queue_depth(
-                                args.recv_posts, receiver_dev, sender_dev
+                                args.recv_posts,
+                                receiver_dev,
+                                sender_dev,
+                                args.apple_queue_depth,
                             )
                             print(
                                 "tbv-uc-stress: "


### PR DESCRIPTION
## Summary
- add `tbv_uc_stress.py --apple-gate` for the Apple compatibility merge-gate matrix
- make the Apple queue-depth cap configurable so we can request depth/count 256 for the short-SEND regression case
- extend `script-syntax` to `py_compile` the Python bench runners

`--apple-gate` forces both directions, 4 KiB and 64 KiB SENDs, count/depth 256, strict checking, fail-fast, and 1500 ms destroy hold. This is the repeatable wrapper for the Linux<->macOS validation still pending on PR #44.

## Validation
- `python -m py_compile userspace/bench/tbv_perftest_runner.py userspace/bench/tbv_rdma_sweep.py userspace/bench/tbv_uc_stress.py`
- `git diff --check`
- `nix build .#checks.x86_64-linux.script-syntax --builders '\ --no-link --print-build-logs`\n- `nix build .#packages.x86_64-linux.bench-tools --builders '\ --no-link --print-build-logs`\n- `nix flake check --no-build --builders '\ --print-build-logs`\n- ran `--apple-gate` over goblin<->mbp (`goblin:rdma_en3` / `mbp:rdma_en2`): all four strict checked cases passed (`4K x 256` and `64K x 256`, both directions)\n\n## Hardware note\nThis does not validate PR #44 by itself because the Linux<->macOS Apple path is currently not visible. It makes that validation a single reproducible command once strix<->goblin is reconnected.\n