### PR TITLE
bench: preflight Apple UC gate devices

### DIFF
--- a/userspace/bench/tbv_uc_stress.py
+++ b/userspace/bench/tbv_uc_stress.py
@@ -70,9 +70,12 @@ WC_ERROR_RE = re.compile(
     r"recv wc error wr_id=\d+ status=(?P<status>\d+) "
     r"opcode=(?P<opcode>\d+) byte_len=(?P<byte_len>\d+)"
 )
+PORT_ACTIVE_RE = re.compile(r"\bstate:\s+PORT_ACTIVE\b")
 APPLE_RDMA_DEV_PREFIX = "rdma_"
 APPLE_RDMA_HOLD_BEFORE_DESTROY_MS = 1000
 APPLE_UC_QUEUE_DEPTH = 32
+SSH_CONFIG = ""
+SSH_OPTIONS: list[str] = []
 
 
 def die(msg: str) -> None:
@@ -94,16 +97,20 @@ def parse_csv_ints(value: str) -> list[int]:
 def ssh_command(host: str, command: str) -> list[str]:
     if host in ("", "local", "localhost"):
         return ["bash", "-lc", command]
-    return [
+    args = [
         "ssh",
         "-o",
         "ConnectTimeout=8",
         "-o",
         "BatchMode=yes",
         "-n",
-        host,
-        command,
     ]
+    if SSH_CONFIG:
+        args.extend(["-F", SSH_CONFIG])
+    for option in SSH_OPTIONS:
+        args.extend(["-o", option])
+    args.extend([host, command])
+    return args
 
 
 def shell_join(args: list[str]) -> str:
@@ -224,6 +231,97 @@ def run_with_timeout(cmd: list[str], timeout: float) -> tuple[int, str]:
         raise
 
 
+def run_host_capture(
+    host: str, command: str, *, timeout: float = 15.0
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ssh_command(host, command),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def connect_host_for_receiver(args: argparse.Namespace, receiver: str) -> str:
+    if args.connect_host:
+        return args.connect_host
+    if receiver == args.server:
+        return args.server_connect_host or receiver
+    if receiver == args.client:
+        return args.client_connect_host or receiver
+    return receiver
+
+
+def preflight_device(host: str, dev: str) -> list[str]:
+    command = "\n".join(
+        [
+            "if ! command -v ibv_devices >/dev/null 2>&1; then",
+            "  echo 'missing ibv_devices in PATH'",
+            "  exit 127",
+            "fi",
+            "if ! command -v ibv_devinfo >/dev/null 2>&1; then",
+            "  echo 'missing ibv_devinfo in PATH'",
+            "  exit 127",
+            "fi",
+            "echo __TBV_IBV_DEVICES__",
+            "ibv_devices",
+            "echo __TBV_IBV_DEVINFO__",
+            f"ibv_devinfo -d {shlex.quote(dev)}",
+        ]
+    )
+    errors: list[str] = []
+    try:
+        proc = run_host_capture(host, command)
+    except subprocess.TimeoutExpired:
+        return [f"{host}:{dev}: preflight timed out"]
+
+    output = proc.stdout or ""
+    if proc.returncode:
+        tail = output.strip()[-500:]
+        return [f"{host}:{dev}: preflight command failed rc={proc.returncode}: {tail}"]
+    if not re.search(rf"(^|\n)\s*{re.escape(dev)}\s", output):
+        errors.append(f"{host}:{dev}: device not listed by ibv_devices")
+    if not PORT_ACTIVE_RE.search(output):
+        errors.append(f"{host}:{dev}: ibv_devinfo did not report PORT_ACTIVE")
+    return errors
+
+
+def run_preflight(args: argparse.Namespace, directions: list[tuple]) -> None:
+    print("tbv-uc-stress: preflight active", flush=True)
+    errors: list[str] = []
+    checked: set[tuple[str, str]] = set()
+
+    for (
+        direction,
+        receiver,
+        sender,
+        receiver_dev,
+        sender_dev,
+        _receiver_gid,
+        _sender_gid,
+    ) in directions:
+        connect_host = connect_host_for_receiver(args, receiver)
+        print(
+            "tbv-uc-stress: preflight "
+            f"{direction}: receiver={receiver}:{receiver_dev} "
+            f"sender={sender}:{sender_dev} connect_host={connect_host}",
+            flush=True,
+        )
+        for host, dev in ((receiver, receiver_dev), (sender, sender_dev)):
+            key = (host, dev)
+            if key in checked:
+                continue
+            checked.add(key)
+            errors.extend(preflight_device(host, dev))
+
+    if errors:
+        die("preflight failed:\n  - " + "\n  - ".join(errors))
+
+    print("tbv-uc-stress: preflight OK", flush=True)
+
+
 def cleanup_port(host: str, tool_basename: str, port: int) -> None:
     pattern = (
         rf"(^|/){re.escape(tool_basename)}([[:space:]]|$)"
@@ -287,14 +385,7 @@ def run_case(
 ) -> dict[str, str]:
     sender_tool = host_tool(args, sender, "send")
     receiver_tool = host_tool(args, receiver, "recv")
-    if args.connect_host:
-        connect_host = args.connect_host
-    elif receiver == args.server:
-        connect_host = args.server_connect_host or receiver
-    elif receiver == args.client:
-        connect_host = args.client_connect_host or receiver
-    else:
-        connect_host = receiver
+    connect_host = connect_host_for_receiver(args, receiver)
     hold_ms = hold_before_destroy_ms(args, receiver_dev, sender_dev)
     recv_depth = apple_queue_depth(
         args.recv_depth, receiver_dev, sender_dev, args.apple_queue_depth
@@ -506,6 +597,35 @@ def main() -> int:
             "and fail-fast."
         ),
     )
+    parser.add_argument(
+        "--preflight",
+        dest="preflight",
+        action="store_true",
+        default=None,
+        help="Check that selected RDMA devices exist and are PORT_ACTIVE before running.",
+    )
+    parser.add_argument(
+        "--no-preflight",
+        dest="preflight",
+        action="store_false",
+        help="Disable the automatic preflight used by --apple-gate.",
+    )
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help="Run preflight checks and exit without starting uc_oneway.",
+    )
+    parser.add_argument(
+        "--ssh-config",
+        default=os.environ.get("TBV_SSH_CONFIG", ""),
+        help="ssh_config file passed to ssh with -F.",
+    )
+    parser.add_argument(
+        "--ssh-option",
+        action="append",
+        default=[],
+        help="extra ssh -o option; may be repeated.",
+    )
     parser.add_argument("--timeout", type=float, default=90.0)
     parser.add_argument("--receiver-drain-timeout", type=float, default=10.0)
     parser.add_argument("--start-delay", type=float, default=1.0)
@@ -525,6 +645,9 @@ def main() -> int:
     parser.add_argument("--strict-order", dest="check_any_order", action="store_false")
     parser.set_defaults(check=True, check_any_order=True)
     args = parser.parse_args()
+    global SSH_CONFIG, SSH_OPTIONS
+    SSH_CONFIG = args.ssh_config or ""
+    SSH_OPTIONS = list(args.ssh_option or [])
 
     if args.apple_gate:
         args.directions = "both"
@@ -552,6 +675,11 @@ def main() -> int:
             flush=True,
         )
 
+    if args.preflight is None:
+        args.preflight = args.apple_gate
+    if args.preflight_only:
+        args.preflight = True
+
     if args.count <= 0:
         die("--count must be positive")
     if args.repeats <= 0:
@@ -566,10 +694,6 @@ def main() -> int:
         die("--apple-queue-depth must be non-negative")
     if args.hold_before_destroy_ms < -1:
         die("--hold-before-destroy-ms must be -1 or non-negative")
-
-    csv_path = Path(args.csv)
-    log_dir = Path(args.log_dir) if args.log_dir else csv_path.with_suffix("")
-    log_dir.mkdir(parents=True, exist_ok=True)
 
     if args.directions == "forward":
         directions = [
@@ -616,6 +740,15 @@ def main() -> int:
                 args.server_gid_index,
             ),
         ]
+
+    if args.preflight:
+        run_preflight(args, directions)
+        if args.preflight_only:
+            return 0
+
+    csv_path = Path(args.csv)
+    log_dir = Path(args.log_dir) if args.log_dir else csv_path.with_suffix("")
+    log_dir.mkdir(parents=True, exist_ok=True)
 
     handle, writer = open_csv(csv_path)
     failures = 0

--- a/userspace/bench/tbv_uc_stress.py
+++ b/userspace/bench/tbv_uc_stress.py
@@ -662,6 +662,7 @@ def main() -> int:
         args.apple_queue_depth = 256
         args.timeout = max(args.timeout, 120.0)
         args.receiver_drain_timeout = max(args.receiver_drain_timeout, 30.0)
+        args.start_delay = max(args.start_delay, 2.0)
         args.hold_before_destroy_ms = max(args.hold_before_destroy_ms, 1500)
         args.stop_on_fail = True
         args.check = True


### PR DESCRIPTION
## Summary
- add `tbv_uc_stress.py --preflight` and `--preflight-only`
- make `--apple-gate` run the preflight by default, with `--no-preflight` as an escape hatch
- preflight verifies selected RDMA devices are listed by `ibv_devices` and report `PORT_ACTIVE` via `ibv_devinfo` before launching any `uc_oneway` traffic
- prints the forward/reverse receiver, sender, and TCP rendezvous host plan so stale topology is obvious before a long run
- add `--ssh-config` / repeated `--ssh-option`, matching the perftest runner style, so the same gate can target hosts reachable through a jump host (for example mbp via goblin)

## Why
The Apple hardware gate was easy to run with stale device names or stale ThunderboltIP addresses. In the current lab state, strix-1/strix-2 only see each other and goblin's stale `en4` address is not backed by an active RDMA port. This makes that failure explicit before the gate starts traffic.

The extra SSH options are needed for the current Mac topology: `mbp.local` is reachable from goblin, while direct local SSH to `mbp` may not route.

## Validation
- `python3 -m py_compile userspace/bench/tbv_uc_stress.py`
- `python3 userspace/bench/tbv_uc_stress.py --help`
- `nix build .#checks.x86_64-linux.script-syntax --builders '' --no-link --print-build-logs`
- `git diff --check`
- positive preflight over the active Mac <-> Mac path using a temporary ssh_config alias:
  - `goblin:rdma_en3` direct
  - `mbp-via-goblin:rdma_en2` via `ProxyJump goblin`
- negative live preflight against current known-bad strix-1/goblin shape:

```sh
python3 userspace/bench/tbv_uc_stress.py \
  --server strix-1 \
  --client goblin \
  --server-dev usb4_rdma4 \
  --client-dev rdma_en4 \
  --server-connect-host 192.168.23.136 \
  --client-connect-host 192.168.23.247 \
  --apple-gate \
  --preflight-only
```

Expected/current result: fails before traffic because `strix-1:usb4_rdma4` is absent and `goblin:rdma_en4` is not `PORT_ACTIVE`.
