### PR TITLE
kernel-workflow: refresh xdomain identity patch for Linux 7.1

### DIFF
--- a/kernel-workflow/patches/0006-thunderbolt-xdomain-bound-response-copy.patch
+++ b/kernel-workflow/patches/0006-thunderbolt-xdomain-bound-response-copy.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: georgewhewell <georgerw@gmail.com>
+Date: Wed, 24 Jun 2026 00:00:00 +0200
+Subject: [PATCH] thunderbolt: xdomain: bound response copy size
+
+When copying an XDomain response into the waiting request buffer, use
+the smaller of the received frame size and the caller-provided response
+buffer size.
+
+This matches the Linux 7.1 xdomain.c baseline and keeps the integration
+patch stack aligned with the portable patch stack before the later
+identity-validation patch tightens payload handling further.
+
+Signed-off-by: georgewhewell <georgerw@gmail.com>
+---
+ drivers/thunderbolt/xdomain.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
+--- a/drivers/thunderbolt/xdomain.c
++++ b/drivers/thunderbolt/xdomain.c
+@@ -122,7 +122,9 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+ static bool tb_xdomain_copy(struct tb_cfg_request *req,
+ 			    const struct ctl_pkg *pkg)
+ {
+-	memcpy(req->response, pkg->buffer, req->response_size);
++	size_t len = min_t(size_t, pkg->frame.size, req->response_size);
++
++	memcpy(req->response, pkg->buffer, len);
+ 	req->result.err = 0;
+ 	return true;
+ }

--- a/kernel-workflow/patches/0009-thunderbolt-xdomain-match-properties-by-identity.patch
+++ b/kernel-workflow/patches/0009-thunderbolt-xdomain-match-properties-by-identity.patch
@@ -9,27 +9,18 @@ property response already carries a stronger transaction identity: the
 reply source/destination UUIDs and the property block offset.
 
 Validate those fields in the matcher and when consuming the response.
-Also copy only the bytes actually present in the received frame and avoid
-casting short scheduled request packets.
+Also copy only the bytes actually present in the received frame.
 
 Signed-off-by: georgewhewell <georgerw@gmail.com>
 ---
- drivers/thunderbolt/xdomain.c | 99 +++++++++++++++++++++++++++++++++--
- 1 file changed, 94 insertions(+), 5 deletions(-)
+ drivers/thunderbolt/xdomain.c | 90 +++++++++++++++++++++++++++++++++-
+ 1 file changed, 87 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/thunderbolt/xdomain.c b/drivers/thunderbolt/xdomain.c
-index d45f032..ccc04a2 100644
+index 395c7cd..e24db9b 100644
 --- a/drivers/thunderbolt/xdomain.c
 +++ b/drivers/thunderbolt/xdomain.c
-@@ -55,6 +55,7 @@ static const char * const state_names[] = {
- struct xdomain_request_work {
- 	struct work_struct work;
- 	struct tb_xdp_header *pkg;
-+	size_t pkg_len;
- 	struct tb *tb;
- };
- 
-@@ -86,6 +87,66 @@ bool tb_is_xdomain_enabled(void)
+@@ -87,6 +87,66 @@ bool tb_is_xdomain_enabled(void)
  	return tb_xdomain_enabled && tb_acpi_is_xdomain_allowed();
  }
  
@@ -96,7 +87,7 @@ index d45f032..ccc04a2 100644
  static bool tb_xdomain_match(const struct tb_cfg_request *req,
  			     const struct ctl_pkg *pkg)
  {
-@@ -97,7 +158,7 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+@@ -98,7 +158,7 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
  		const struct tb_xdp_header *res_hdr = pkg->buffer;
  		const struct tb_xdp_header *req_hdr = req->request;
  
@@ -105,7 +96,7 @@ index d45f032..ccc04a2 100644
  			return false;
  
  		/* Make sure route matches */
-@@ -111,6 +172,13 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+@@ -112,6 +172,13 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
  		if (!uuid_equal(&res_hdr->uuid, &req_hdr->uuid))
  			return false;
  
@@ -119,11 +110,13 @@ index d45f032..ccc04a2 100644
  		return true;
  	}
  
-@@ -122,7 +190,11 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
+@@ -123,8 +190,10 @@ static bool tb_xdomain_match(const struct tb_cfg_request *req,
  static bool tb_xdomain_copy(struct tb_cfg_request *req,
  			    const struct ctl_pkg *pkg)
  {
--	memcpy(req->response, pkg->buffer, req->response_size);
+-	size_t len = min_t(size_t, pkg->frame.size, req->response_size);
+-
+-	memcpy(req->response, pkg->buffer, len);
 +	size_t len = min_t(size_t, tb_xdomain_frame_payload_size(pkg),
 +			   req->response_size);
 +
@@ -131,8 +124,7 @@ index d45f032..ccc04a2 100644
 +	memcpy(req->response, pkg->buffer, len);
  	req->result.err = 0;
  	return true;
- }
-@@ -367,7 +439,7 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+@@ -370,7 +439,7 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
  		 * least size of the response structure.
  		 */
  		len = res->hdr.xd_hdr.length_sn & TB_XDOMAIN_LENGTH_MASK;
@@ -141,7 +133,7 @@ index d45f032..ccc04a2 100644
  			ret = -EINVAL;
  			goto err;
  		}
-@@ -375,11 +447,26 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
+@@ -378,11 +447,26 @@ static int tb_xdp_properties_request(struct tb_ctl *ctl, u64 route,
  		len += sizeof(res->hdr.xd_hdr) / 4;
  		len -= sizeof(*res) / 4;
  
@@ -168,32 +160,5 @@ index d45f032..ccc04a2 100644
  		/*
  		 * First time allocate block that has enough space for
  		 * the whole properties block.
-@@ -786,7 +873,7 @@ static void tb_xdp_handle_request(struct work_struct *work)
- 	switch (pkg->type) {
- 	case PROPERTIES_REQUEST:
- 		tb_dbg(tb, "%llx: received XDomain properties request\n", route);
--		if (xd) {
-+		if (xd && xw->pkg_len >= sizeof(struct tb_xdp_properties)) {
- 			ret = tb_xdp_properties_response(tb, ctl, xd, sequence,
- 				(const struct tb_xdp_properties *)pkg);
- 		}
-@@ -879,7 +966,8 @@ static void tb_xdp_handle_request(struct work_struct *work)
- 		tb_dbg(tb, "%llx: received XDomain link state change request\n",
- 		       route);
- 
--		if (xd && xd->state == XDOMAIN_STATE_BONDING_UUID_HIGH) {
-+		if (xd && xd->state == XDOMAIN_STATE_BONDING_UUID_HIGH &&
-+		    xw->pkg_len >= sizeof(struct tb_xdp_link_state_change)) {
- 			const struct tb_xdp_link_state_change *lsc =
- 				(const struct tb_xdp_link_state_change *)pkg;
- 
-@@ -932,6 +1020,7 @@ tb_xdp_schedule_request(struct tb *tb, const struct tb_xdp_header *hdr,
- 		kfree(xw);
- 		return false;
- 	}
-+	xw->pkg_len = size;
- 	xw->tb = tb_domain_get(tb);
- 
- 	schedule_work(&xw->work);
 -- 
 2.54.0

--- a/kernel-workflow/patches/local-integration-debug.nix
+++ b/kernel-workflow/patches/local-integration-debug.nix
@@ -3,4 +3,8 @@
     name = "usb4-nhi-ring-debugfs-instrumentation";
     patch = ./0003-thunderbolt-nhi-add-ring-debugfs-instrumentation.patch;
   }
+  {
+    name = "usb4-xdomain-bound-response-copy";
+    patch = ./0006-thunderbolt-xdomain-bound-response-copy.patch;
+  }
 ]


### PR DESCRIPTION
## Summary
- refresh the portable `0009-thunderbolt-xdomain-match-properties-by-identity.patch` against Linux 7.1
- drop hunks that Linux 7.1 already carries for bounded scheduled XDomain request handling
- keep the property-response identity and bounds validation changes
- add an integration-only prep patch so the local Linux 7.1 integration stack has the bounded `tb_xdomain_copy()` context that stock Linux 7.1 already has

## Verification
- `git diff --check origin/main...HEAD`
- `nix build .#checks.x86_64-linux.portable-kernel-patches --no-link --print-build-logs`
- `nix build .#packages.x86_64-linux.linux-thunderbolt.configfile --no-link --print-build-logs`
- `nix build .#hydraJobs.x86_64-linux.linux-thunderbolt-modules --no-link --print-build-logs`

This addresses the Hydra failures from `hellas:thunderbolt-ibverbs-pr-49:x86_64-linux.checks.portable-kernel-patches` and `hellas:thunderbolt-ibverbs-pr-50:x86_64-linux.linux-thunderbolt-modules`.